### PR TITLE
Makefile: allow buliding with podman too

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ FROM gcr.io/distroless/static-debian12:nonroot
 
 WORKDIR /app
 COPY --from=builder /app/fdo_server /app/fdo_server
-USER nonroot
 
 ENTRYPOINT ["./fdo_server"]
 CMD []

--- a/Makefile
+++ b/Makefile
@@ -17,14 +17,15 @@ RESALE_GUID =
 RESALE_KEY =
 REUSE_CRED =
 WGET_URLS =
+CONTAINER_RUNTIME ?= docker
 
 # Build the Docker image
 build:
-	docker build -t $(IMAGE_NAME) .
+	${CONTAINER_RUNTIME} build -t $(IMAGE_NAME) .
 
 # Run the Docker container with all flags
 run:
-	docker run -v $(PWD)/app-data:/app-data:rw --name $(CONTAINER_NAME) -d --network=$(NETWORK) $(IMAGE_NAME) \
+	${CONTAINER_RUNTIME} run -v $(PWD)/app-data:/app-data:rw --name $(CONTAINER_NAME) -d --network=$(NETWORK) $(IMAGE_NAME) \
 		-db $(DB_PATH) \
 		$(if $(DB_PASS),-db-pass $(DB_PASS)) \
 		$(DEBUG) \
@@ -43,17 +44,17 @@ run:
 
 # Docker stop
 stop:
-	docker stop $(CONTAINER_NAME)
-	docker rm $(CONTAINER_NAME)
+	${CONTAINER_RUNTIME} stop $(CONTAINER_NAME)
+	${CONTAINER_RUNTIME} rm $(CONTAINER_NAME)
 
 # Clean up Docker images
 clean:
-	docker rmi $(IMAGE_NAME)
+	${CONTAINER_RUNTIME} rmi $(IMAGE_NAME)
 
 # Copy Upload Files to host
 copy:
 	@for upfile in $(UPLOAD_FILES); do \
-                docker cp $(CONTAINER_NAME):/app/$$upfile ./app-data; \
+                ${CONTAINER_RUNTIME} cp $(CONTAINER_NAME):/app/$$upfile ./app-data; \
                 done
 
 # Default target

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ build:
 # Run the Docker container with all flags
 run:
 	${CONTAINER_RUNTIME} run -v $(PWD)/app-data:/app-data:rw --name $(CONTAINER_NAME) -d --network=$(NETWORK) $(IMAGE_NAME) \
-		-db $(DB_PATH) \
+		-db /home/nonroot/$(DB_PATH) \
 		$(if $(DB_PASS),-db-pass $(DB_PASS)) \
 		$(DEBUG) \
 		-http $(HTTP_ADDR) \

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ TO0 will be completed in the respective Owner and RV.
 
 ### Prerequisites
 
-- Docker
+- Container runtime (Docker or Podman)
 - Make
 
 ### Makefile Targets
@@ -194,11 +194,12 @@ TO0 will be completed in the respective Owner and RV.
 
 The following variables can be set to customize the behavior of the `make run` command:
 
-- `IMAGE_NAME`: The name of the Docker image (default: `fdo_server`).
-- `CONTAINER_NAME`: The name of the Docker container (default: `fdo_server`).
+- `CONTAINER_RUNTIME`: The container runtime executable to use (default: `docker`).
+- `IMAGE_NAME`: The name of the container image (default: `fdo_server`).
+- `CONTAINER_NAME`: The name of the container (default: `fdo_server`).
 - `DB_PATH`: The path to the SQLite database file (default: `./test.db`).
 - `DB_PASS`: The SQLite database encryption-at-rest passphrase. **NOTE**:This field should be populated before starting the container.
-- `NETWORK`: The Docker network setting (default: `host`).
+- `NETWORK`: The container network setting (default: `host`).
 - `DEBUG`: Debug flag to print HTTP contents (default: `--debug`).
 - `HTTP_ADDR`: The address to listen on (default: `localhost:8080`).
 - `EXT_HTTP_ADDR`: The external address devices should connect to (default: `127.0.0.1:8080`).
@@ -215,16 +216,16 @@ The following variables can be set to customize the behavior of the `make run` c
 
 ## Usage
 
-### Building the Docker Image
+### Building the container image
 
-To build the Docker image, run:
+To build the container image, run:
 
 ```console
 make build
 ```
 
-### Running the Docker Container
-To start the FDO Go service as a Docker container, run:
+### Running the container
+To start the FDO Go service as a container, run:
 
 ```console
 make run
@@ -236,14 +237,14 @@ make copy
 ```
 This will copy the files uploaded using fdo.upload FSIM module to `app-data` folder present in host system.
 
-### Stoping the Docker Container
-To stop the Docker Container, run:
+### Stoping the container
+To stop the container, run:
 ```console
 make stop
 ```
 
 ### Default Target
-To build and run the Docker container in one step, run:
+To build and run the container in one step, run:
 ```console
 make all
 ```


### PR DESCRIPTION
I have `podman` available on my Fedora system and I'd love to use it to build the project. This patch just makes it possible to default to `docker` but allows for different container runtimes too (e.g. `make build CONTAINER_RUNTIME=podman`)