### PR TITLE
fix: import/export PEM voucher

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,15 +149,16 @@ Use GET and PUT requests to view and update existing owner redirect data.
 
 ## Fetch and Post Voucher
 Fetch a Voucher
+
 Fetch a voucher using curl and save it to a file named ownervoucher:
 ```
 curl --location --request GET 'http://localhost:8038/api/v1/vouchers?guid=<guid>' -o ownervoucher
 ```
-Post the Voucher to RV and Owner Server
-Post the fetched voucher to the RV and Owner server using curl:
+Post the Voucher to the Owner Server
+
+Post the fetched voucher to the Owner server using curl:
 ```
-curl -X POST 'http://localhost:8041/api/v1/owner/vouchers' -d @ownervoucher
-curl -X POST 'http://localhost:8043/api/v1/owner/vouchers' -d @ownervoucher
+curl -X POST 'http://localhost:8043/api/v1/owner/vouchers' --data-binary @ownervoucher
 ```
 ## Execute DI from the FDO GO Client.
 For Running the FDO GO Client setup, please refer to the FDO Go Client README.

--- a/api/handlers/to0.go
+++ b/api/handlers/to0.go
@@ -5,22 +5,17 @@ package handlers
 
 import (
 	"net/http"
-	"path"
 
-	"github.com/fido-device-onboard/go-fdo-server/internal/utils"
-
-	"github.com/fido-device-onboard/go-fdo-server/internal/to0"
 	"github.com/fido-device-onboard/go-fdo/protocol"
 	"github.com/fido-device-onboard/go-fdo/sqlite"
+
+	"github.com/fido-device-onboard/go-fdo-server/internal/to0"
+	"github.com/fido-device-onboard/go-fdo-server/internal/utils"
 )
 
 func To0Handler(rvInfo *[][]protocol.RvInstruction, state *sqlite.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		to0Guid := path.Base(r.URL.Path)
-		if to0Guid == "" {
-			http.Error(w, "GUID is required", http.StatusBadRequest)
-			return
-		}
+		to0Guid := r.PathValue("guid")
 
 		if !utils.IsValidGUID(to0Guid) {
 			http.Error(w, "GUID is not a valid GUID", http.StatusBadRequest)
@@ -37,6 +32,6 @@ func To0Handler(rvInfo *[][]protocol.RvInstruction, state *sqlite.DB) http.Handl
 
 		w.Header().Set("Content-Type", "text/plain")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(to0Guid))
+		_, _ = w.Write([]byte(to0Guid))
 	}
 }

--- a/api/handlers/vouchers.go
+++ b/api/handlers/vouchers.go
@@ -88,6 +88,14 @@ func InsertVoucherHandler(rvInfo *[][]protocol.RvInstruction) http.HandlerFunc {
 				return
 			}
 
+			if dbOv, err := db.FetchVoucher(ov.Header.Val.GUID[:]); err == nil {
+				if bytes.Equal(block.Bytes, dbOv.CBOR) {
+					slog.Debug("Voucher already exists", "guid", ov.Header.Val.GUID[:])
+					continue
+				}
+				slog.Debug("Voucher guid already exists. not overwriting it", "guid", ov.Header.Val.GUID[:])
+			}
+
 			// Check that voucher owner key matches
 			expectedPubKey, err := ov.OwnerPublicKey()
 			if err != nil {

--- a/api/routes.go
+++ b/api/routes.go
@@ -56,7 +56,7 @@ func (h *HTTPHandler) RegisterRoutes() *http.ServeMux {
 	apiRouter := http.NewServeMux()
 	apiRouter.Handle("/rvinfo", handlers.RvInfoHandler(h.rvInfo))
 	apiRouter.HandleFunc("/owner/redirect", handlers.OwnerInfoHandler)
-	apiRouter.Handle("/to0/", handlers.To0Handler(h.rvInfo, h.state))
+	apiRouter.Handle("GET /to0/{guid}", handlers.To0Handler(h.rvInfo, h.state))
 	apiRouter.HandleFunc("GET /vouchers", handlers.GetVoucherHandler)
 	apiRouter.Handle("POST /owner/vouchers", handlers.InsertVoucherHandler(h.rvInfo))
 

--- a/api/routes.go
+++ b/api/routes.go
@@ -4,13 +4,16 @@
 package api
 
 import (
-	"golang.org/x/time/rate"
+	"io"
 	"net/http"
 
-	"github.com/fido-device-onboard/go-fdo-server/api/handlers"
+	"golang.org/x/time/rate"
+
 	transport "github.com/fido-device-onboard/go-fdo/http"
 	"github.com/fido-device-onboard/go-fdo/protocol"
 	"github.com/fido-device-onboard/go-fdo/sqlite"
+
+	"github.com/fido-device-onboard/go-fdo-server/api/handlers"
 )
 
 // HTTPHandler handles HTTP requests
@@ -20,14 +23,27 @@ type HTTPHandler struct {
 	state   *sqlite.DB
 }
 
-func rateLimitMiddleware(limiter *rate.Limiter, next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+func rateLimitMiddleware(limiter *rate.Limiter, next http.Handler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
 		if !limiter.Allow() {
 			http.Error(w, "Too Many Requests", http.StatusTooManyRequests)
 			return
 		}
 		next.ServeHTTP(w, r)
-	})
+	}
+}
+
+func bodySizeMiddleware(limitBytes int64, next http.Handler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		r.Body = struct {
+			io.Reader
+			io.Closer
+		}{
+			Reader: io.LimitReader(r.Body, limitBytes),
+			Closer: r.Body,
+		}
+		next.ServeHTTP(w, r)
+	}
 }
 
 // NewHTTPHandler creates a new HTTPHandler
@@ -37,25 +53,22 @@ func NewHTTPHandler(handler *transport.Handler, rvInfo *[][]protocol.RvInstructi
 
 // RegisterRoutes registers the routes for the HTTP server
 func (h *HTTPHandler) RegisterRoutes() *http.ServeMux {
-	handler := http.NewServeMux()
-	limiter := rate.NewLimiter(2, 10)
+	apiRouter := http.NewServeMux()
+	apiRouter.Handle("/rvinfo", handlers.RvInfoHandler(h.rvInfo))
+	apiRouter.HandleFunc("/owner/redirect", handlers.OwnerInfoHandler)
+	apiRouter.Handle("/to0/", handlers.To0Handler(h.rvInfo, h.state))
+	apiRouter.HandleFunc("GET /vouchers", handlers.GetVoucherHandler)
+	apiRouter.Handle("POST /owner/vouchers", handlers.InsertVoucherHandler(h.rvInfo))
 
+	apiHandler := rateLimitMiddleware(rate.NewLimiter(2, 10),
+		bodySizeMiddleware(1<<20, /* 1MB */
+			apiRouter,
+		),
+	)
+
+	handler := http.NewServeMux()
 	handler.Handle("POST /fdo/101/msg/{msg}", h.handler)
-	handler.HandleFunc("/api/v1/rvinfo", func(w http.ResponseWriter, r *http.Request) {
-		rateLimitMiddleware(limiter, http.HandlerFunc(handlers.RvInfoHandler(h.rvInfo))).ServeHTTP(w, r)
-	})
-	handler.HandleFunc("/api/v1/owner/redirect", func(w http.ResponseWriter, r *http.Request) {
-		rateLimitMiddleware(limiter, http.HandlerFunc(handlers.OwnerInfoHandler)).ServeHTTP(w, r)
-	})
-	handler.HandleFunc("/api/v1/to0/", func(w http.ResponseWriter, r *http.Request) {
-		rateLimitMiddleware(limiter, http.HandlerFunc(handlers.To0Handler(h.rvInfo, h.state))).ServeHTTP(w, r)
-	})
-	handler.HandleFunc("/api/v1/vouchers", func(w http.ResponseWriter, r *http.Request) {
-		rateLimitMiddleware(limiter, http.HandlerFunc(handlers.GetVoucherHandler)).ServeHTTP(w, r)
-	})
-	handler.HandleFunc("/api/v1/owner/vouchers", func(w http.ResponseWriter, r *http.Request) {
-		rateLimitMiddleware(limiter, http.HandlerFunc(handlers.InsertVoucherHandler(h.rvInfo))).ServeHTTP(w, r)
-	})
+	handler.Handle("/api/v1/", http.StripPrefix("/api/v1", apiHandler))
 	handler.HandleFunc("/health", handlers.HealthHandler)
 	return handler
 }

--- a/cmd/import_voucher.go
+++ b/cmd/import_voucher.go
@@ -56,6 +56,7 @@ var importVoucherCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("error parsing owner public key from voucher: %w", err)
 		}
+		// TODO: Allow importing vouchers with RSA 2048 manufacturer keys
 		ownerKey, _, err := state.OwnerKey(context.Background(), ov.Header.Val.ManufacturerKey.Type, 3072)
 		if err != nil {
 			return fmt.Errorf("error getting owner key: %w", err)


### PR DESCRIPTION
Fix https://github.com/fido-device-onboard/go-fdo-server/issues/22

This patch changes the way importing and exporting a voucher was
handled. For some reason, it was dealing with jsons of voucher/owner
keys. This makes it so that it deals only with PEM voucher and owner
keys verification is left out to be implemented elsewhere.