### PR TITLE
Use correct Content-type value in API responses

### DIFF
--- a/api/handlers/ownerinfo.go
+++ b/api/handlers/ownerinfo.go
@@ -77,8 +77,8 @@ func createOwnerData(w http.ResponseWriter, r *http.Request, mu *sync.Mutex) {
 
 	slog.Debug("ownerData created")
 
-	w.WriteHeader(http.StatusCreated)
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
 	json.NewEncoder(w).Encode(ownerData)
 }
 

--- a/api/handlers/rvinfo.go
+++ b/api/handlers/rvinfo.go
@@ -90,8 +90,8 @@ func createRvData(w http.ResponseWriter, r *http.Request, rvInfo *[][]protocol.R
 		return
 	}
 
-	w.WriteHeader(http.StatusCreated)
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
 	json.NewEncoder(w).Encode(rvData)
 }
 

--- a/api/handlers/to0.go
+++ b/api/handlers/to0.go
@@ -4,9 +4,10 @@
 package handlers
 
 import (
-	"github.com/fido-device-onboard/go-fdo-server/internal/utils"
 	"net/http"
 	"path"
+
+	"github.com/fido-device-onboard/go-fdo-server/internal/utils"
 
 	"github.com/fido-device-onboard/go-fdo-server/internal/to0"
 	"github.com/fido-device-onboard/go-fdo/protocol"
@@ -34,6 +35,7 @@ func To0Handler(rvInfo *[][]protocol.RvInstruction, state *sqlite.DB) http.Handl
 			}
 		}
 
+		w.Header().Set("Content-Type", "text/plain")
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(to0Guid))
 	}

--- a/api/handlers/vouchers.go
+++ b/api/handlers/vouchers.go
@@ -8,8 +8,9 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"github.com/fido-device-onboard/go-fdo-server/internal/utils"
 	"net/http"
+
+	"github.com/fido-device-onboard/go-fdo-server/internal/utils"
 
 	"log/slog"
 
@@ -106,6 +107,7 @@ func InsertVoucherHandler(rvInfo *[][]protocol.RvInstruction) http.HandlerFunc {
 			return
 		}
 		*rvInfo = newRvInfo
+		w.Header().Set("Content-Type", "text/plain")
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(guidHex))
 	}


### PR DESCRIPTION
Properly orders calls to http.ResponseWriter.WriteHeader() after setting
all response headers via calls to http.ResponseWriter.Header.().Set()

Closes #31