### PR TITLE
fix: set the log level in PersistentPreRun hook

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,6 +33,11 @@ var rootCmd = &cobra.Command{
 
 	The server also provides APIs to interact with the various servers implementations.
 `,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		if debug {
+			logLevel.Set(slog.LevelDebug)
+		}
+	},
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -54,10 +59,6 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&dbPass, "db-pass", "", "SQLite database encryption-at-rest passphrase")
 	rootCmd.MarkPersistentFlagRequired("db")
 	rootCmd.MarkPersistentFlagRequired("db-pass")
-
-	if debug {
-		logLevel.Set(slog.LevelDebug)
-	}
 }
 
 const (


### PR DESCRIPTION
The persistent commands and flags are parsed just before executing the command, not in the init() function. As the debug flag is a persistent flag, we can use the `PersistentPrerun` hook to make sure the `debug` variable has been updated with the actual value.

Fixes: #36