### PR TITLE
rpm: add runtime Requires for openssl on manufacturer server

### DIFF
--- a/build/package/rpm/go-fdo-server.spec
+++ b/build/package/rpm/go-fdo-server.spec
@@ -83,6 +83,7 @@ install -m 0755 -vp -D -t %{buildroot}%{_datadir}/%{name} scripts/*
 %package manufacturer
 Requires: go-fdo-server
 Requires: group(go-fdo-server)
+Requires: openssl
 Summary: A Go implementation of the FDO manufacturer server
 License: %combined_license
 %description manufacturer


### PR DESCRIPTION
The generate-manufacturer-certs.sh helper (invoked by go-fdo-server-manufacturer.service) calls openssl at service start to generate keys and certificates. On minimal/container images the openssl binary may be missing which causes the manufacturing service to fail to start.