### PR TITLE
Add comprehensive OV verification for owner server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,35 @@ jobs:
           source test/ci/test-onboarding.sh
           cleanup
 
+  test-ov-verification:
+    name: Test Ownership Voucher verification
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install golang
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Test Ownership Voucher verification
+        run: |
+          source test/ci/test-ov-verification.sh
+          run_test
+
+      - name: Get manufacturer, rendezvous and owner server logs after a failure
+        if: failure()
+        run: |
+          source test/ci/test-ov-verification.sh
+          get_server_logs
+
+      - name: Cleanup the environment
+        if: always()
+        run: |
+          source test/ci/test-ov-verification.sh
+          cleanup
+
   test-resale:
     name: Test FIDO resale protocol
     runs-on: ubuntu-latest

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -38,6 +38,36 @@ jobs:
           source test/container/test-onboarding.sh
           cleanup
 
+  test-container-ov-verification:
+    name: Test Ownership Voucher verification
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Install golang
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Test Ownership Voucher verification
+        run: |
+          source test/container/test-ov-verification.sh
+          run_test
+
+      - name: Get manufacturer, rendezvous and owner server logs after failure
+        if: failure()
+        run: |
+          source test/container/test-ov-verification.sh
+          get_server_logs
+
+      - name: Cleanup the environment
+        if: always()
+        run: |
+          source test/container/test-ov-verification.sh
+          cleanup
+
   test-container-resale:
     name: Test FIDO resale protocol
     runs-on: ubuntu-latest

--- a/api/handlersTest/vouchers_test.go
+++ b/api/handlersTest/vouchers_test.go
@@ -1,0 +1,346 @@
+// SPDX-FileCopyrightText: (C) 2024 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
+
+package handlersTest
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/fido-device-onboard/go-fdo"
+	"github.com/fido-device-onboard/go-fdo-server/api/handlers"
+	"github.com/fido-device-onboard/go-fdo-server/internal/db"
+	"github.com/fido-device-onboard/go-fdo/cbor"
+	"github.com/fido-device-onboard/go-fdo/sqlite"
+	"github.com/fido-device-onboard/go-fdo/testdata"
+)
+
+func setupTestDB(t *testing.T) {
+	testDB, err := sqlite.Open(":memory:", "")
+	if err != nil {
+		t.Fatalf("Failed to open test database: %v", err)
+	}
+
+	err = db.InitDb(testDB)
+	if err != nil {
+		t.Fatalf("Failed to initialize test database: %v", err)
+	}
+}
+
+type testData struct {
+	validVoucherPEM        []byte
+	corruptedPEM           []byte
+	invalidCBORPEM         []byte
+	invalidPEM             []byte
+	ownerPublicKey         crypto.PublicKey // For unextended voucher (manufacturer key)
+	extendedOwnerPublicKey crypto.PublicKey // For extended voucher (next owner key)
+}
+
+func setupTestData(t *testing.T) *testData {
+	// Load voucher from testdata on go-fdo library
+	voucherPEM, err := testdata.Files.ReadFile("ov.pem")
+	if err != nil {
+		t.Fatalf("Failed to read test voucher: %v", err)
+	}
+
+	// Parse voucher
+	block, _ := pem.Decode(voucherPEM)
+	if block == nil {
+		t.Fatal("Failed to decode PEM from testdata")
+	}
+
+	var voucher fdo.Voucher
+	if err := cbor.Unmarshal(block.Bytes, &voucher); err != nil {
+		t.Fatalf("Failed to unmarshal voucher: %v", err)
+	}
+
+	ownerPubKey, err := voucher.OwnerPublicKey()
+	if err != nil {
+		t.Fatalf("Failed to get owner public key: %v", err)
+	}
+
+	// Load manufacturer key and extend voucher (to create Entries for signature test)
+	mfgKeyPEM, err := testdata.Files.ReadFile("mfg_key.pem")
+	if err != nil {
+		t.Fatalf("Failed to read manufacturer key: %v", err)
+	}
+	mfgKeyBlock, _ := pem.Decode(mfgKeyPEM)
+	if mfgKeyBlock == nil {
+		t.Fatal("Failed to decode manufacturer key PEM")
+	}
+	mfgKey, err := x509.ParseECPrivateKey(mfgKeyBlock.Bytes)
+	if err != nil {
+		t.Fatalf("Failed to parse manufacturer key: %v", err)
+	}
+
+	nextOwnerKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		t.Fatalf("Failed to generate next owner key: %v", err)
+	}
+
+	extendedVoucher, err := fdo.ExtendVoucher(&voucher, mfgKey, nextOwnerKey.Public().(*ecdsa.PublicKey), nil)
+	if err != nil {
+		t.Fatalf("Failed to extend voucher: %v", err)
+	}
+
+	// Create corrupted voucher with invalid signature
+	extendedVoucher.Entries[0].Signature = make([]byte, 96)
+	for i := range extendedVoucher.Entries[0].Signature {
+		extendedVoucher.Entries[0].Signature[i] = 0xFF
+	}
+	corruptedBytes, _ := cbor.Marshal(extendedVoucher)
+	corruptedPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "OWNERSHIP VOUCHER",
+		Bytes: corruptedBytes,
+	})
+
+	// Create invalid CBOR voucher
+	invalidCBOR := []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xAB, 0xCD}
+	invalidCBORPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "OWNERSHIP VOUCHER",
+		Bytes: invalidCBOR,
+	})
+
+	return &testData{
+		validVoucherPEM:        voucherPEM,
+		corruptedPEM:           corruptedPEM,
+		invalidCBORPEM:         invalidCBORPEM,
+		invalidPEM:             []byte("This is not valid PEM data at all"),
+		ownerPublicKey:         ownerPubKey,           // Manufacturer key (for unextended voucher)
+		extendedOwnerPublicKey: nextOwnerKey.Public(), // Next owner key (for extended voucher)
+	}
+}
+
+type voucherTestCase struct {
+	name               string
+	voucherData        []byte
+	ownerKey           crypto.PublicKey // Owner key to configure handler with
+	expectedStatusCode int
+	expectedBodyOneOf  []string
+}
+
+func TestInsertVoucherHandler(t *testing.T) {
+	setupTestDB(t)
+	testData := setupTestData(t)
+
+	testCases := []voucherTestCase{
+		{
+			// Valid unextended voucher
+			name:               "Valid voucher is accepted",
+			voucherData:        testData.validVoucherPEM,
+			ownerKey:           testData.ownerPublicKey, // Manufacturer key
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			// Extended voucher with corrupted signature
+			name:               "Corrupted signature is rejected",
+			voucherData:        testData.corruptedPEM,
+			ownerKey:           testData.extendedOwnerPublicKey, // Next owner key
+			expectedStatusCode: http.StatusBadRequest,
+			expectedBodyOneOf: []string{
+				"Invalid ownership voucher\n",
+			},
+		},
+		{
+			// Verify voucher CBOR encoding integrity
+			name:               "Invalid CBOR is rejected",
+			voucherData:        testData.invalidCBORPEM,
+			ownerKey:           testData.ownerPublicKey, // Doesn't matter, fails before key check
+			expectedStatusCode: http.StatusBadRequest,
+			expectedBodyOneOf: []string{
+				"Unable to decode cbor\n",
+			},
+		},
+		{
+			// Verify PEM encoding integrity
+			name:               "Invalid PEM is rejected",
+			voucherData:        testData.invalidPEM,
+			ownerKey:           testData.ownerPublicKey, // Doesn't matter, fails before key check
+			expectedStatusCode: http.StatusBadRequest,
+			expectedBodyOneOf: []string{
+				"Unable to decode PEM content\n",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create HTTP request
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/owner/vouchers", bytes.NewReader(tc.voucherData))
+			rec := httptest.NewRecorder()
+
+			// Create handler with appropriate owner key for this test case
+			handler := handlers.InsertVoucherHandler([]crypto.PublicKey{tc.ownerKey})
+
+			// Call handler
+			handler(rec, req)
+
+			// Verify status code
+			if rec.Code != tc.expectedStatusCode {
+				t.Errorf("Expected status %d, got %d: %s", tc.expectedStatusCode, rec.Code, rec.Body.String())
+			}
+
+			if len(tc.expectedBodyOneOf) > 0 {
+				body := rec.Body.String()
+				found := false
+				for _, expected := range tc.expectedBodyOneOf {
+					if body == expected {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("Expected one of %v, got: %s", tc.expectedBodyOneOf, body)
+				}
+			}
+		})
+	}
+}
+
+// Valid voucher with wrong/fake owner key should be rejected.
+func TestInsertVoucherHandler_WrongOwnerKey(t *testing.T) {
+	setupTestDB(t)
+
+	voucherPEM, err := testdata.Files.ReadFile("ov.pem")
+	if err != nil {
+		t.Fatalf("Failed to read test voucher: %v", err)
+	}
+	wrongOwnerKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		t.Fatalf("Failed to generate wrong owner key: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/owner/vouchers", bytes.NewReader(voucherPEM))
+	rec := httptest.NewRecorder()
+	handler := handlers.InsertVoucherHandler([]crypto.PublicKey{wrongOwnerKey.Public()})
+	handler(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("Expected status 400 Bad Request for wrong owner key, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	expectedError := "Invalid ownership voucher\n"
+	if body != expectedError {
+		t.Errorf("Expected error '%s', got: '%s'", expectedError, body)
+	}
+}
+
+// Test vouchers with invalid header fields are rejected.
+func TestInsertVoucherHandler_InvalidHeaderFields(t *testing.T) {
+	setupTestDB(t)
+
+	// Load valid voucher as base
+	voucherPEM, err := testdata.Files.ReadFile("ov.pem")
+	if err != nil {
+		t.Fatalf("Failed to read test voucher: %v", err)
+	}
+	block, _ := pem.Decode(voucherPEM)
+	if block == nil {
+		t.Fatal("Failed to decode PEM from testdata")
+	}
+	var baseVoucher fdo.Voucher
+	if err := cbor.Unmarshal(block.Bytes, &baseVoucher); err != nil {
+		t.Fatalf("Failed to unmarshal voucher: %v", err)
+	}
+	ownerPubKey, err := baseVoucher.OwnerPublicKey()
+	if err != nil {
+		t.Fatalf("Failed to get owner public key: %v", err)
+	}
+
+	// TODO: This should reference a common constant once FDOProtocolVersion is moved to a common package
+	// See: api/handlers/vouchers.go VerifyOwnershipVoucher function for related TODO
+	const fdoProtocolVersion uint16 = 101 // FDO spec v1.1
+
+	testCases := []struct {
+		name          string
+		modifyVoucher func(*fdo.Voucher)
+		expectedError string
+	}{
+		{
+			name: "Invalid protocol version",
+			modifyVoucher: func(v *fdo.Voucher) {
+				v.Version = 999 // Invalid version
+				v.Header.Val.Version = 999
+			},
+			expectedError: "Invalid ownership voucher\n",
+		},
+		{
+			name: "Protocol version mismatch",
+			modifyVoucher: func(v *fdo.Voucher) {
+				v.Version = fdoProtocolVersion
+				v.Header.Val.Version = 100 // Mismatch
+			},
+			expectedError: "Invalid ownership voucher\n",
+		},
+		{
+			name: "Zero GUID",
+			modifyVoucher: func(v *fdo.Voucher) {
+				// Set GUID to all zeros (invalid)
+				for i := range v.Header.Val.GUID {
+					v.Header.Val.GUID[i] = 0
+				}
+			},
+			expectedError: "Invalid ownership voucher\n",
+		},
+		{
+			name: "Empty DeviceInfo",
+			modifyVoucher: func(v *fdo.Voucher) {
+				v.Header.Val.DeviceInfo = ""
+			},
+			expectedError: "Invalid ownership voucher\n",
+		},
+		{
+			name: "Invalid ManufacturerKey",
+			modifyVoucher: func(v *fdo.Voucher) {
+				v.Header.Val.ManufacturerKey.Type = 0 // Invalid type
+			},
+			expectedError: "Invalid ownership voucher\n",
+		},
+		{
+			name: "Empty RvInfo",
+			modifyVoucher: func(v *fdo.Voucher) {
+				v.Header.Val.RvInfo = nil
+			},
+			expectedError: "Invalid ownership voucher\n",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a copy of the base voucher
+			var voucher fdo.Voucher
+			if err := cbor.Unmarshal(block.Bytes, &voucher); err != nil {
+				t.Fatalf("Failed to unmarshal voucher: %v", err)
+			}
+			tc.modifyVoucher(&voucher)
+			modifiedBytes, err := cbor.Marshal(&voucher)
+			if err != nil {
+				t.Fatalf("Failed to marshal modified voucher: %v", err)
+			}
+			modifiedPEM := pem.EncodeToMemory(&pem.Block{
+				Type:  "OWNERSHIP VOUCHER",
+				Bytes: modifiedBytes,
+			})
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/owner/vouchers", bytes.NewReader(modifiedPEM))
+			rec := httptest.NewRecorder()
+
+			// Create handler with correct owner key and verify response for each invalid voucher
+			handler := handlers.InsertVoucherHandler([]crypto.PublicKey{ownerPubKey})
+			handler(rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("Expected status 400 Bad Request, got %d: %s", rec.Code, rec.Body.String())
+			}
+			body := rec.Body.String()
+			if body != tc.expectedError {
+				t.Errorf("Expected error '%s', got: '%s'", tc.expectedError, body)
+			}
+		})
+	}
+}

--- a/cmd/owner.go
+++ b/cmd/owner.go
@@ -207,6 +207,9 @@ func serveOwner(db *sqlite.DB, useTLS bool) error {
 		},
 		Modules:         moduleStateMachines{DB: state.DB, states: make(map[string]*moduleStateMachineState)},
 		ReuseCredential: func(context.Context, fdo.Voucher) (bool, error) { return reuseCred, nil },
+		VerifyVoucher: func(_ context.Context, voucher fdo.Voucher) error {
+			return handlers.VerifyVoucher(&voucher, []crypto.PublicKey{state.ownerKey.Public()})
+		},
 	}
 
 	handler := &transport.Handler{

--- a/deployments/compose/server/fdo-ov-verification-servers.yaml
+++ b/deployments/compose/server/fdo-ov-verification-servers.yaml
@@ -1,0 +1,2 @@
+include:
+  - fdo-resale-servers.yaml

--- a/test/ci/test-ov-verification.sh
+++ b/test/ci/test-ov-verification.sh
@@ -1,0 +1,73 @@
+#! /bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )/test-resale.sh"
+
+run_test () {
+  # Add the new owner service for wrong owner test
+  services+=("${new_owner_service_name}")
+
+  echo "⭐ Creating directories"
+  create_directories
+
+  echo "⭐ Generating service certificates"
+  generate_certs
+
+  echo "⭐ Build and install 'go-fdo-client' binary"
+  install_client
+
+  echo "⭐ Build and install 'go-fdo-server' binary"
+  install_server
+
+  echo "⭐ Start services"
+  start_services
+
+  echo "⭐ Wait for the services to be ready:"
+  wait_for_services_ready
+
+  echo "⭐ Setting or updating Rendezvous Info (RendezvousInfo)"
+  set_or_update_rendezvous_info "${manufacturer_url}" "${rendezvous_service_name}" "${rendezvous_dns}" "${rendezvous_port}"
+
+  echo "⭐ Run Device Initialization"
+  run_device_initialization
+
+  guid=$(get_device_guid ${device_credentials})
+  echo "⭐ Device initialized with GUID: ${guid}"
+
+  echo "⭐ Get valid voucher from manufacturer"
+  valid_ov="${base_dir}/valid.ov"
+  get_ov_from_manufacturer "${manufacturer_url}" "${guid}" "${valid_ov}"
+
+  echo "  ⭐ Test 1: Valid voucher should be accepted"
+  send_ov_to_owner "${owner_url}" "${valid_ov}" 2>&1 || { echo "  ❌ This test was supposed to succeed"; return 1; }
+  echo "  ✅ Valid voucher accepted"
+
+  # NOTE: We use approximate offset-based corruption (not precise field-level corruption).
+  # Precise field-level corruption is tested in unit tests (api/handlersTest/vouchers_test.go).
+  # This approach is sufficient for E2E validation.
+
+  echo "  ⭐ Test 2: Corrupted voucher signature should be rejected"
+  corrupted_ov="${base_dir}/corrupted_sig.ov"
+  cp "${valid_ov}" "${corrupted_ov}"
+  printf '\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF' | dd of="${corrupted_ov}" bs=1 seek=200 count=10 conv=notrunc 2>/dev/null
+  ! send_ov_to_owner "${owner_url}" "${corrupted_ov}" 2>&1 || { echo "  ❌ This test was supposed to fail"; return 1; }
+  echo "  ✅ Corrupted voucher rejected"
+
+  echo "  ⭐ Test 3: Voucher with invalid cert chain hash should be rejected"
+  invalid_hash_ov="${base_dir}/invalid_hash.ov"
+  cp "${valid_ov}" "${invalid_hash_ov}"
+  printf '\xAA\xBB\xCC\xDD\xEE\xFF' | dd of="${invalid_hash_ov}" bs=1 seek=120 count=6 conv=notrunc 2>/dev/null
+  ! send_ov_to_owner "${owner_url}" "${invalid_hash_ov}" 2>&1 || { echo "  ❌ This test was supposed to fail"; return 1; }
+  echo "  ✅ Voucher with invalid cert chain hash rejected"
+
+  echo "  ⭐ Test 4: Voucher sent to wrong owner should be rejected"
+  ! send_manufacturer_ov_to_owner "${manufacturer_url}" "${guid}" "${new_owner_url}" 2>&1 || { echo "  ❌ This test was supposed to fail"; return 1; }
+  echo "  ✅ New owner correctly rejected voucher (owner key doesn't match)"
+
+  echo "⭐ Success! ✅"
+  trap cleanup EXIT
+}
+
+# Allow running directly
+[[ "${BASH_SOURCE[0]}" != "$0" ]] || run_test

--- a/test/container/test-ov-verification.sh
+++ b/test/container/test-ov-verification.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+set -euo pipefail
+
+source "$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )/../ci/test-ov-verification.sh"
+source "$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )/utils.sh"
+
+client_compose_file="deployments/compose/client/fdo-client.yaml"
+servers_compose_file="deployments/compose/server/fdo-ov-verification-servers.yaml"
+
+# Allow running directly
+[[ "${BASH_SOURCE[0]}" != "$0" ]] || run_test


### PR DESCRIPTION
This PR: 
- prevents owner server from storing invalid/corrupted/fake ov into the databse
- Unit tests and e2e CI tests are added
