### PR TITLE
ci: adds e2e tests for centos/epel in packit

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -145,3 +145,17 @@ jobs:
       - fedora-latest-stable
       - fedora-latest
       - fedora-rawhide
+
+  - job: tests
+    trigger: pull_request
+    identifier: e2e-centos
+    fmf_path: test/fmf
+    tmt_plan: plans/e2e
+    packages: [go-fdo-server-centos]
+    additional_packages:
+      - go-fdo-server-manufacturer
+      - go-fdo-server-rendezvous
+      - go-fdo-server-owner
+    targets:
+      - epel-9
+      - epel-10

--- a/test/fmf/plans/e2e.fmf
+++ b/test/fmf/plans/e2e.fmf
@@ -14,7 +14,12 @@ provision:
     disk: 10GB
 
 prepare:
-    how: install
+  - how: shell
+    script: |
+      # Enable COPR to get go-fdo-client
+      dnf install -y 'dnf-command(copr)'
+      dnf copr enable -y @fedora-iot/fedora-iot
+  - how: install
     package:
       - go-fdo-server
       - go-fdo-server-manufacturer


### PR DESCRIPTION
Adds test configuration to packit to enable centos testing with epel 9 and epel 10 targets, following existing Fedora structure.