### PR TITLE
fix: use basename for download FSIM to avoid relative path issues

### DIFF
--- a/cmd/owner.go
+++ b/cmd/owner.go
@@ -385,7 +385,7 @@ func ownerModules(modules []string) iter.Seq2[string, serviceinfo.OwnerModule] {
 				defer func() { _ = f.Close() }()
 
 				if !yield("fdo.download", &fsim.DownloadContents[*os.File]{
-					Name:         name,
+					Name:         filepath.Base(name),
 					Contents:     f,
 					MustDownload: true,
 				}) {

--- a/test/ci/test-fsim-download.sh
+++ b/test/ci/test-fsim-download.sh
@@ -9,9 +9,9 @@ fsim_download_dir="${base_dir}/fsim/download"
 owner_download_dir="${fsim_download_dir}/owner"
 device_download_dir="${fsim_download_dir}/device"
 
-# downloads using relative subdir paths doesn't work
-#download_files=("relative1" "subdir1/relative2" "subdir1/subdir2/relative3" "${owner_download_dir}/absolute")
-download_files=("file1" "${owner_download_dir}/file2" "${owner_download_dir}/subdir1/file3")
+# Test both relative and absolute paths with the fix
+download_files=("file1" "subdir1/relative2" "${owner_download_dir}/file3")
+# Original failing test: download_files=("relative1" "subdir1/relative2" "subdir1/subdir2/relative3" "${owner_download_dir}/absolute")
 
 # Overwrite the owner service start function to configure download FSIM
 start_service_owner() {


### PR DESCRIPTION
When using relative paths with subdirectories in --command-download (e.g., 'downloads/file.txt'), the client would fail trying to create nested directory structures. This fix ensures only the basename is used as the filename, consistent with how absolute paths and wget FSIM are handled.

Also updates test to verify relative paths with subdirectories work correctly.

Fixes https://github.com/fido-device-onboard/go-fdo/issues/169