### PR TITLE
fix: remove error message from clean systemd shutdown

### DIFF
--- a/cmd/manufacturing.go
+++ b/cmd/manufacturing.go
@@ -154,9 +154,17 @@ func (s *ManufacturingServer) Start() error {
 			MinVersion:   tls.VersionTLS12,
 			CipherSuites: preferredCipherSuites,
 		}
-		return srv.ServeTLS(lis, s.config.CertPath, s.config.KeyPath)
+		err := srv.ServeTLS(lis, s.config.CertPath, s.config.KeyPath)
+		if err != nil && err != http.ErrServerClosed {
+			return err
+		}
+		return nil
 	}
-	return srv.Serve(lis)
+	err = srv.Serve(lis)
+	if err != nil && err != http.ErrServerClosed {
+		return err
+	}
+	return nil
 }
 
 func serveManufacturing(config *ManufacturingServerConfig) error {

--- a/cmd/owner.go
+++ b/cmd/owner.go
@@ -175,9 +175,17 @@ func (s *OwnerServer) Start() error {
 			MinVersion:   tls.VersionTLS12,
 			CipherSuites: preferredCipherSuites,
 		}
-		return srv.ServeTLS(lis, s.config.CertPath, s.config.KeyPath)
+		err := srv.ServeTLS(lis, s.config.CertPath, s.config.KeyPath)
+		if err != nil && err != http.ErrServerClosed {
+			return err
+		}
+		return nil
 	}
-	return srv.Serve(lis)
+	err = srv.Serve(lis)
+	if err != nil && err != http.ErrServerClosed {
+		return err
+	}
+	return nil
 }
 
 type OwnerServerState struct {

--- a/cmd/rendezvous.go
+++ b/cmd/rendezvous.go
@@ -111,9 +111,17 @@ func (s *RendezvousServer) Start() error {
 			MinVersion:   tls.VersionTLS12,
 			CipherSuites: preferredCipherSuites,
 		}
-		return srv.ServeTLS(lis, s.config.CertPath, s.config.KeyPath)
+		err := srv.ServeTLS(lis, s.config.CertPath, s.config.KeyPath)
+		if err != nil && err != http.ErrServerClosed {
+			return err
+		}
+		return nil
 	}
-	return srv.Serve(lis)
+	err = srv.Serve(lis)
+	if err != nil && err != http.ErrServerClosed {
+		return err
+	}
+	return nil
 }
 
 type RendezvousServerState struct {


### PR DESCRIPTION
Enables clean systemd shutdown, removing unintended error message and returning 0 status. 

Fixes #121 