### PR TITLE
fix: download source tarball in post-modifications action

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -25,6 +25,7 @@ srpm_build_deps:
   - go-vendor-tools
   - python3-tomlkit
   - askalono-cli
+  - rpmdevtools
 
 packages:
   go-fdo-server-fedora:
@@ -59,6 +60,8 @@ actions:
       export BASE_DIR=${PACKIT_UPSTREAM_REPO}/build/package/rpm
       export GO_VENDOR_TOOLS_CONFIG=${BASE_DIR}/go-vendor-tools.toml
       export SPEC_FILE=${BASE_DIR}/go-fdo-server.spec
+      # Download the source tarball (Source0) needed by go_vendor_archive
+      spectool -g -C ${BASE_DIR} ${SPEC_FILE}
       go_vendor_archive create --config ${GO_VENDOR_TOOLS_CONFIG} ${SPEC_FILE}
       go_vendor_license \
         --config ${GO_VENDOR_TOOLS_CONFIG} \


### PR DESCRIPTION
The post-modifications action was failing in the propose_downstream workflow because go_vendor_archive requires the source tarball (Source0) to exist before it can create the vendor archive.

In the Packit sandcastle build environment, the source tarball is not available at the expected location when post-modifications runs. This caused the error:

  FileNotFoundError: [Errno 2] No such file or directory:
  '.../go-fdo-server-<commit>.tar.gz'

Add spectool command to download the source tarball from the GitHub release before running go_vendor_archive. Also add rpmdevtools to srpm_build_deps to ensure spectool is available in the build environment.

This fix allows the propose_downstream job to succeed when triggered by a new GitHub release.

Fixes: https://dashboard.packit.dev/jobs/propose-downstream/22429