### PR TITLE
fix: use correct spec file path in post-modifications action

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -56,7 +56,7 @@ actions:
       bash -xc '
       #! /bin/bash
       export GOTOOLCHAIN=auto
-      export BASE_DIR=${PACKIT_UPSTREAM_REPO}/build/package/rpm
+      export BASE_DIR=build/package/rpm
       export GO_VENDOR_TOOLS_CONFIG=${BASE_DIR}/go-vendor-tools.toml
       export SPEC_FILE=${BASE_DIR}/go-fdo-server.spec
       go_vendor_archive create --config ${GO_VENDOR_TOOLS_CONFIG} ${SPEC_FILE}


### PR DESCRIPTION
The post-modifications action was reading the spec file from ${PACKIT_UPSTREAM_REPO}/build/package/rpm instead of the relative path build/package/rpm. This caused it to read the unmodified spec file with the old hardcoded commit hash, rather than the spec file that had been updated by fix-spec-file with the correct release commit hash.

As a result, spectool downloaded the wrong source tarball during the propose_downstream workflow, as noted in PR #131.

Change post-modifications to use the same relative path as fix-spec-file (build/package/rpm), ensuring both actions operate on the same updated spec file.

Fixes: https://dashboard.packit.dev/jobs/propose-downstream/22467
Related: https://github.com/fido-device-onboard/go-fdo-server/pull/131