### PR TITLE
ci: skip bootc test on rawhide

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -134,7 +134,9 @@ jobs:
     identifier: bootc-e2e-fedora
     tmt_plan: test/fmf/plans/bootc-e2e
     packages: [go-fdo-server-fedora]
-    targets: *copr_fedora_targets
+    targets: # Temporarily disabling rawhide due to bug https://issues.redhat.com/browse/HMS-9867
+      - "fedora-latest-stable-x86_64"
+      - "fedora-latest-stable-aarch64"
 
   # CentOS jobs
 


### PR DESCRIPTION
This is to fix ci errors due to bug https://issues.redhat.com/browse/HMS-9867