### PR TITLE
ci: add a short default delay to rvinfo test configuration

### DIFF
--- a/scripts/fdo-utils.sh
+++ b/scripts/fdo-utils.sh
@@ -14,7 +14,14 @@ set_rendezvous_info () {
   local rendezvous_ip=$3
   local rendezvous_port=$4
   local rendezvous_protocol=$5
-  local rendezvous_info="[{\"dns\": \"${rendezvous_dns}\", \"device_port\": \"${rendezvous_port}\", \"protocol\": \"${rendezvous_protocol}\", \"ip\": \"${rendezvous_ip}\", \"owner_port\": \"${rendezvous_port}\"}]"
+  local delay_seconds=${6:-}
+
+  local rendezvous_info="\"dns\": \"${rendezvous_dns}\", \"device_port\": \"${rendezvous_port}\", \"protocol\": \"${rendezvous_protocol}\", \"ip\": \"${rendezvous_ip}\", \"owner_port\": \"${rendezvous_port}\""
+  if [ -n "${delay_seconds}" ]; then
+    rendezvous_info="${rendezvous_info}, \"delay_seconds\": ${delay_seconds}"
+  fi
+  rendezvous_info="[{${rendezvous_info}}]"
+
   curl --fail --verbose --silent --insecure \
        --request POST \
        --header 'Content-Type: text/plain' \
@@ -28,7 +35,14 @@ update_rendezvous_info () {
   local rendezvous_ip=$3
   local rendezvous_port=$4
   local rendezvous_protocol=$5
-  local rendezvous_info="[{\"dns\": \"${rendezvous_dns}\", \"device_port\": \"${rendezvous_port}\", \"protocol\": \"${rendezvous_protocol}\", \"ip\": \"${rendezvous_ip}\", \"owner_port\": \"${rendezvous_port}\"}]"
+  local delay_seconds=${6:-}
+
+  local rendezvous_info="\"dns\": \"${rendezvous_dns}\", \"device_port\": \"${rendezvous_port}\", \"protocol\": \"${rendezvous_protocol}\", \"ip\": \"${rendezvous_ip}\", \"owner_port\": \"${rendezvous_port}\""
+  if [ -n "${delay_seconds}" ]; then
+    rendezvous_info="${rendezvous_info}, \"delay_seconds\": ${delay_seconds}"
+  fi
+  rendezvous_info="[{${rendezvous_info}}]"
+
   curl --fail --verbose --silent --insecure \
        --request PUT \
        --header 'Content-Type: text/plain' \

--- a/test/ci/utils.sh
+++ b/test/ci/utils.sh
@@ -447,15 +447,17 @@ set_or_update_rendezvous_info() {
   local rendezvous_port=$4
   local rendezvous_protocol=${5:-http}
 
+  # to speed up the tests, override the default delay of 120 seconds
+  local delay_seconds=10
   local real_rendezvous_ip
   real_rendezvous_ip="$(get_real_ip "${rendezvous_service_name}")"
   log_info "Checking if 'RendezvousInfo' is configured on manufacturer side (${manufacturer_url})"
   if [ -z "$(get_rendezvous_info "${manufacturer_url}")" ]; then
     log_warn "'RendezvousInfo' not found, creating it"
-    set_rendezvous_info "${manufacturer_url}" "${rendezvous_dns}" "${real_rendezvous_ip}" "${rendezvous_port}" "${rendezvous_protocol}"
+    set_rendezvous_info "${manufacturer_url}" "${rendezvous_dns}" "${real_rendezvous_ip}" "${rendezvous_port}" "${rendezvous_protocol}" "${delay_seconds}"
   else
     log_info "'RendezvousInfo' found, updating it"
-    update_rendezvous_info "${manufacturer_url}" "${rendezvous_dns}" "${real_rendezvous_ip}" "${rendezvous_port}" "${rendezvous_protocol}"
+    update_rendezvous_info "${manufacturer_url}" "${rendezvous_dns}" "${real_rendezvous_ip}" "${rendezvous_port}" "${rendezvous_protocol}" "${delay_seconds}"
   fi
   echo
 }


### PR DESCRIPTION
The go-fdo-client will delay between onboarding failures. By default this delay is around 120 seconds.

The PR modifies the tests to configure a short 10 second delay to override that long default. This shortens the time it takes to run the CI tests.