### PR TITLE
fix(test): properly propagate exit codes from run_go_fdo_client

### DIFF
--- a/test/ci/utils.sh
+++ b/test/ci/utils.sh
@@ -257,8 +257,13 @@ run_go_fdo_client() {
   cd "${credentials_dir}"
   # If the command times out, the return code is 124 (see: man timeout)
   # If the command finishes before the timeout, the return code comes from 'go-fdo-client'
-  timeout ${client_timeout} go-fdo-client "$@" || log_warn "'go-fdo-client' command exited with '$?' (124 -> timeout):\n  - go-fdo-client $*"
+  local exit_code=0
+  timeout "${client_timeout}" go-fdo-client "$@" || exit_code=$?
+  if [[ ${exit_code} -ne 0 ]]; then
+    log_warn "'go-fdo-client' exited with '${exit_code}' (124 -> timeout):\n  - go-fdo-client $*"
+  fi
   cd - >/dev/null
+  return ${exit_code}
 }
 
 run_device_initialization() {

--- a/test/container/utils.sh
+++ b/test/container/utils.sh
@@ -56,7 +56,12 @@ run_go_fdo_client() {
     # Replace base_dir with container_working_dir in paths
     args+=("${arg//$base_dir/$container_working_dir}")
   done
-  timeout "${client_timeout}" docker compose --file "${client_compose_file}" run --rm go-fdo-client "${args[@]}" || log_warn "Command timed out ($?): 'go-fdo-client $*'"
+  local exit_code=0
+  timeout "${client_timeout}" docker compose --file "${client_compose_file}" run --rm go-fdo-client "${args[@]}" || exit_code=$?
+  if [[ ${exit_code} -ne 0 ]]; then
+    log_warn "Command timed out (${exit_code}): 'go-fdo-client $*'"
+  fi
+  return ${exit_code}
 }
 
 install_server() {


### PR DESCRIPTION
` $?`  contains the exit code of the last executed command.
which happens to be `log_warn` so it will return 0 (log warn:sucess)instead of actual exit_code of go-fdo-client.
Lets capture it first and then print it.
