### PR TITLE
feat: add automatic database cleanup for rendezvous server

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -322,6 +322,11 @@ The rendezvous server configuration is under the `[rendezvous]` section:
 |-----|------|-------------|---------|
 | `to0_min_wait` | integer | Minimum wait time in seconds for TO0 rendezvous entries. Requests below this value are rejected. Set to 0 for no minimum. | 0 |
 | `to0_max_wait` | integer | Maximum wait time in seconds for TO0 rendezvous entries. Requests above this value are accepted but capped at this maximum. This prevents owner servers from registering rendezvous blobs for excessively long periods. | 86400 (24 hours) |
+| `cleanup_interval` | integer | Interval in seconds for automatic cleanup of expired rendezvous blobs and sessions. The cleanup task runs periodically in the background, removing rendezvous blobs that have exceeded their expiration time and sessions older than `session_timeout` to prevent database bloat. Set to 0 to disable automatic cleanup (not recommended for production). | 3600 (1 hour) |
+| `session_timeout` | integer | Maximum age in seconds for protocol sessions (TO0/TO1) before cleanup. Sessions older than this age will be deleted during periodic cleanup, along with their associated session data. This prevents accumulation of orphaned sessions from interrupted or failed protocol exchanges. | 3600 (1 hour) |
+| `initial_cleanup_delay` | integer | Delay in seconds before the first cleanup runs after server startup. This prevents startup spikes when restarting servers with large amounts of expired data, allowing the server to start serving requests before running potentially heavy cleanup operations. | 300 (5 minutes) |
+
+**Note**: The rendezvous server performs periodic background cleanup to prevent database bloat. Expired rendezvous blobs and old sessions are automatically removed based on the configured intervals.
 
 ## Configuration File Examples
 
@@ -430,6 +435,11 @@ dsn = "file:rendezvous.db"
 # TO0 wait time limits
 to0_min_wait = 0        # No minimum (default)
 to0_max_wait = 86400    # 24 hours (default)
+
+# Database cleanup configuration
+cleanup_interval = 3600         # Run cleanup every hour (default)
+session_timeout = 3600          # Delete sessions older than 1 hour (default)
+initial_cleanup_delay = 300     # Wait 5 minutes before first cleanup (default)
 ```
 
 ### YAML Configuration Example
@@ -531,6 +541,11 @@ rendezvous:
   # TO0 wait time limits
   to0_min_wait: 0        # No minimum (default)
   to0_max_wait: 86400    # 24 hours (default)
+
+  # Database cleanup configuration
+  cleanup_interval: 3600         # Run cleanup every hour (default)
+  session_timeout: 3600          # Delete sessions older than 1 hour (default)
+  initial_cleanup_delay: 300     # Wait 5 minutes before first cleanup (default)
 ```
 
 ## Notes

--- a/configs/rendezvous.yaml
+++ b/configs/rendezvous.yaml
@@ -28,3 +28,24 @@ rendezvous:
   # This prevents owner servers from registering rendezvous blobs for excessively long periods.
   # Default: 86400 (24 hours)
   ##to0_max_wait: 86400
+
+  # Interval in seconds for automatic cleanup of expired rendezvous blobs and sessions from the database.
+  # The cleanup task runs periodically in the background, removing rendezvous blobs that
+  # have exceeded their expiration time and sessions older than session_timeout
+  # to prevent database bloat.
+  # Set to 0 to disable automatic cleanup (not recommended for production).
+  # Default: 3600 (1 hour)
+  ##cleanup_interval: 3600
+
+  # Maximum age in seconds for protocol sessions (TO0/TO1) before cleanup.
+  # Sessions older than this age will be deleted during periodic cleanup, along with
+  # their associated session data. This prevents accumulation of orphaned sessions
+  # from interrupted or failed protocol exchanges.
+  # Default: 3600 (1 hour)
+  ##session_timeout: 3600
+
+  # Delay in seconds before the first cleanup runs after server startup.
+  # This prevents startup spikes when restarting servers with large amounts of expired data,
+  # allowing the server to start serving requests before running potentially heavy cleanup operations.
+  # Default: 300 (5 minutes)
+  ##initial_cleanup_delay: 300

--- a/internal/state/cascade_test.go
+++ b/internal/state/cascade_test.go
@@ -1,0 +1,213 @@
+// SPDX-FileCopyrightText: (C) 2024 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
+
+package state
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/fido-device-onboard/go-fdo/protocol"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupCascadeTestDB(t *testing.T) *gorm.DB {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("Failed to open in-memory database: %v", err)
+	}
+
+	// Enable foreign key constraints in SQLite (disabled by default!)
+	if err := db.Exec("PRAGMA foreign_keys = ON").Error; err != nil {
+		t.Fatalf("Failed to enable foreign keys: %v", err)
+	}
+
+	return db
+}
+
+func TestCascadeDeleteTO0Sessions(t *testing.T) {
+	db := setupCascadeTestDB(t)
+	ctx := context.Background()
+
+	// Initialize token service (creates sessions table)
+	tokenService, err := InitTokenServiceDB(db)
+	if err != nil {
+		t.Fatalf("Failed to initialize token service: %v", err)
+	}
+
+	// Initialize TO0 session state (creates to0_sessions table with FK)
+	to0State, err := InitTO0SessionDB(db)
+	if err != nil {
+		t.Fatalf("Failed to initialize TO0 session DB: %v", err)
+	}
+
+	// Create a session with TO0 protocol
+	token, err := tokenService.NewToken(ctx, protocol.TO0Protocol)
+	if err != nil {
+		t.Fatalf("Failed to create token: %v", err)
+	}
+
+	// Add token to context
+	ctx = tokenService.TokenContext(ctx, token)
+
+	// Create a TO0 session entry
+	nonce := protocol.Nonce{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	if err := to0State.SetTO0SignNonce(ctx, nonce); err != nil {
+		t.Fatalf("Failed to set TO0 sign nonce: %v", err)
+	}
+
+	// Verify TO0 session exists
+	var to0Count int64
+	db.Model(&TO0Session{}).Count(&to0Count)
+	if to0Count != 1 {
+		t.Fatalf("Expected 1 TO0 session, got %d", to0Count)
+	}
+
+	// Delete the parent session
+	sessionID, err := tokenService.getSessionID(ctx)
+	if err != nil {
+		t.Fatalf("Failed to get session ID: %v", err)
+	}
+
+	if err := db.Delete(&Session{}, "id = ?", sessionID).Error; err != nil {
+		t.Fatalf("Failed to delete session: %v", err)
+	}
+
+	// Verify TO0 session was automatically deleted via CASCADE
+	db.Model(&TO0Session{}).Count(&to0Count)
+	if to0Count != 0 {
+		t.Errorf("Expected 0 TO0 sessions after cascade delete, got %d", to0Count)
+		t.Error("CASCADE DELETE is not working - TO0 sessions are orphaned")
+	}
+}
+
+func TestCascadeDeleteTO1Sessions(t *testing.T) {
+	db := setupCascadeTestDB(t)
+	ctx := context.Background()
+
+	// Initialize token service
+	tokenService, err := InitTokenServiceDB(db)
+	if err != nil {
+		t.Fatalf("Failed to initialize token service: %v", err)
+	}
+
+	// Initialize TO1 session state
+	to1State, err := InitTO1SessionDB(db)
+	if err != nil {
+		t.Fatalf("Failed to initialize TO1 session DB: %v", err)
+	}
+
+	// Create a session with TO1 protocol
+	token, err := tokenService.NewToken(ctx, protocol.TO1Protocol)
+	if err != nil {
+		t.Fatalf("Failed to create token: %v", err)
+	}
+
+	ctx = tokenService.TokenContext(ctx, token)
+
+	// Create a TO1 session entry
+	nonce := protocol.Nonce{16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1}
+	if err := to1State.SetTO1ProofNonce(ctx, nonce); err != nil {
+		t.Fatalf("Failed to set TO1 proof nonce: %v", err)
+	}
+
+	// Verify TO1 session exists
+	var to1Count int64
+	db.Model(&TO1Session{}).Count(&to1Count)
+	if to1Count != 1 {
+		t.Fatalf("Expected 1 TO1 session, got %d", to1Count)
+	}
+
+	// Delete the parent session
+	sessionID, err := tokenService.getSessionID(ctx)
+	if err != nil {
+		t.Fatalf("Failed to get session ID: %v", err)
+	}
+
+	if err := db.Delete(&Session{}, "id = ?", sessionID).Error; err != nil {
+		t.Fatalf("Failed to delete session: %v", err)
+	}
+
+	// Verify TO1 session was automatically deleted via CASCADE
+	db.Model(&TO1Session{}).Count(&to1Count)
+	if to1Count != 0 {
+		t.Errorf("Expected 0 TO1 sessions after cascade delete, got %d", to1Count)
+		t.Error("CASCADE DELETE is not working - TO1 sessions are orphaned")
+	}
+}
+
+func TestSessionCleanupCascadesToProtocolSessions(t *testing.T) {
+	db := setupCascadeTestDB(t)
+	ctx := context.Background()
+
+	// Initialize all session states
+	tokenService, err := InitTokenServiceDB(db)
+	if err != nil {
+		t.Fatalf("Failed to initialize token service: %v", err)
+	}
+
+	to0State, err := InitTO0SessionDB(db)
+	if err != nil {
+		t.Fatalf("Failed to initialize TO0 session DB: %v", err)
+	}
+
+	to1State, err := InitTO1SessionDB(db)
+	if err != nil {
+		t.Fatalf("Failed to initialize TO1 session DB: %v", err)
+	}
+
+	// Create an old TO0 session
+	token0, err := tokenService.NewToken(ctx, protocol.TO0Protocol)
+	if err != nil {
+		t.Fatalf("Failed to create TO0 token: %v", err)
+	}
+	ctx0 := tokenService.TokenContext(ctx, token0)
+	if err := to0State.SetTO0SignNonce(ctx0, protocol.Nonce{1, 2, 3}); err != nil {
+		t.Fatalf("Failed to set TO0 nonce: %v", err)
+	}
+
+	// Create an old TO1 session
+	token1, err := tokenService.NewToken(ctx, protocol.TO1Protocol)
+	if err != nil {
+		t.Fatalf("Failed to create TO1 token: %v", err)
+	}
+	ctx1 := tokenService.TokenContext(ctx, token1)
+	if err := to1State.SetTO1ProofNonce(ctx1, protocol.Nonce{4, 5, 6}); err != nil {
+		t.Fatalf("Failed to set TO1 nonce: %v", err)
+	}
+
+	// Make both sessions old by updating their created_at timestamp
+	db.Model(&Session{}).Where("protocol = ?", protocol.TO0Protocol).
+		Update("created_at", db.NowFunc().Add(-2*time.Hour))
+	db.Model(&Session{}).Where("protocol = ?", protocol.TO1Protocol).
+		Update("created_at", db.NowFunc().Add(-2*time.Hour))
+
+	// Verify both protocol sessions exist
+	var to0Count, to1Count int64
+	db.Model(&TO0Session{}).Count(&to0Count)
+	db.Model(&TO1Session{}).Count(&to1Count)
+	if to0Count != 1 || to1Count != 1 {
+		t.Fatalf("Expected 1 TO0 and 1 TO1 session, got %d and %d", to0Count, to1Count)
+	}
+
+	// Run session cleanup (should delete both old sessions)
+	deletedCount, err := tokenService.CleanupExpiredSessions(ctx, 1*time.Hour)
+	if err != nil {
+		t.Fatalf("Cleanup failed: %v", err)
+	}
+	if deletedCount != 2 {
+		t.Fatalf("Expected 2 sessions deleted, got %d", deletedCount)
+	}
+
+	// Verify protocol sessions were CASCADE deleted
+	db.Model(&TO0Session{}).Count(&to0Count)
+	db.Model(&TO1Session{}).Count(&to1Count)
+	if to0Count != 0 {
+		t.Errorf("Expected 0 TO0 sessions after cleanup, got %d - CASCADE DELETE not working", to0Count)
+	}
+	if to1Count != 0 {
+		t.Errorf("Expected 0 TO1 sessions after cleanup, got %d - CASCADE DELETE not working", to1Count)
+	}
+}

--- a/internal/state/rvblob.go
+++ b/internal/state/rvblob.go
@@ -108,3 +108,16 @@ func (s RendezvousBlobPersistentState) RVBlob(ctx context.Context, guid protocol
 
 	return &to1d, &voucher, nil
 }
+
+// CleanupExpiredBlobs deletes all rendezvous blobs that have expired
+// Returns the number of deleted blobs and any error encountered
+func (s RendezvousBlobPersistentState) CleanupExpiredBlobs(ctx context.Context) (int64, error) {
+	result := s.DB.WithContext(ctx).Where("exp < ?", time.Now()).Delete(&RvBlob{})
+	if result.Error != nil {
+		return 0, fmt.Errorf("failed to cleanup expired rv blobs: %w", result.Error)
+	}
+	if result.RowsAffected > 0 {
+		slog.Debug("Cleaned up expired rendezvous blobs", "count", result.RowsAffected)
+	}
+	return result.RowsAffected, nil
+}

--- a/internal/state/rvblob_test.go
+++ b/internal/state/rvblob_test.go
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: (C) 2024 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
+
+package state
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/fido-device-onboard/go-fdo"
+	"github.com/fido-device-onboard/go-fdo/cbor"
+	"github.com/fido-device-onboard/go-fdo/cose"
+	"github.com/fido-device-onboard/go-fdo/protocol"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupTestDB(t *testing.T) *gorm.DB {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("Failed to open in-memory database: %v", err)
+	}
+
+	// Enable foreign key constraints in SQLite (required for CASCADE DELETE)
+	if err := db.Exec("PRAGMA foreign_keys = ON").Error; err != nil {
+		t.Fatalf("Failed to enable foreign keys: %v", err)
+	}
+
+	return db
+}
+
+func TestCleanupExpiredBlobs(t *testing.T) {
+	db := setupTestDB(t)
+	state, err := InitRendezvousBlobDB(db)
+	if err != nil {
+		t.Fatalf("Failed to initialize rendezvous blob DB: %v", err)
+	}
+
+	// Create test voucher and to1d
+	guid := protocol.GUID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	voucher := &fdo.Voucher{
+		Header: cbor.Bstr[fdo.VoucherHeader]{
+			Val: fdo.VoucherHeader{
+				GUID: guid,
+			},
+		},
+	}
+	to1d := &cose.Sign1[protocol.To1d, []byte]{}
+
+	ctx := context.Background()
+
+	// Insert an expired blob
+	expiredTime := time.Now().Add(-1 * time.Hour)
+	if err := state.SetRVBlob(ctx, voucher, to1d, expiredTime); err != nil {
+		t.Fatalf("Failed to set expired blob: %v", err)
+	}
+
+	// Insert a non-expired blob
+	guid2 := protocol.GUID{16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1}
+	voucher = &fdo.Voucher{
+		Header: cbor.Bstr[fdo.VoucherHeader]{
+			Val: fdo.VoucherHeader{
+				GUID: guid2,
+			},
+		},
+	}
+	futureTime := time.Now().Add(1 * time.Hour)
+	if err := state.SetRVBlob(ctx, voucher, to1d, futureTime); err != nil {
+		t.Fatalf("Failed to set non-expired blob: %v", err)
+	}
+
+	// Verify both blobs exist in DB
+	var count int64
+	db.Model(&RvBlob{}).Count(&count)
+	if count != 2 {
+		t.Fatalf("Expected 2 blobs, got %d", count)
+	}
+
+	// Run cleanup
+	deletedCount, err := state.CleanupExpiredBlobs(ctx)
+	if err != nil {
+		t.Fatalf("Cleanup failed: %v", err)
+	}
+	if deletedCount != 1 {
+		t.Fatalf("Expected 1 blob to be deleted, got %d", deletedCount)
+	}
+
+	// Verify only the non-expired blob remains
+	db.Model(&RvBlob{}).Count(&count)
+	if count != 1 {
+		t.Fatalf("Expected 1 blob after cleanup, got %d", count)
+	}
+
+	// Verify the remaining blob is the non-expired one
+	var rvBlob RvBlob
+	if err := db.First(&rvBlob).Error; err != nil {
+		t.Fatalf("Failed to retrieve remaining blob: %v", err)
+	}
+	expectedGUID := []byte{16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1}
+	for i := range expectedGUID {
+		if rvBlob.GUID[i] != expectedGUID[i] {
+			t.Fatalf("Remaining blob has wrong GUID")
+		}
+	}
+}

--- a/internal/state/token_test.go
+++ b/internal/state/token_test.go
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: (C) 2024 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
+
+package state
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/fido-device-onboard/go-fdo"
+	"github.com/fido-device-onboard/go-fdo/protocol"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupTestTokenDB(t *testing.T) *gorm.DB {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("Failed to open in-memory database: %v", err)
+	}
+
+	// Enable foreign key constraints in SQLite (required for CASCADE DELETE)
+	if err := db.Exec("PRAGMA foreign_keys = ON").Error; err != nil {
+		t.Fatalf("Failed to enable foreign keys: %v", err)
+	}
+
+	return db
+}
+
+func TestCleanupExpiredSessions(t *testing.T) {
+	db := setupTestTokenDB(t)
+	tokenService, err := InitTokenServiceDB(db)
+	if err != nil {
+		t.Fatalf("Failed to initialize token service DB: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// Create a new session (this will be the stale one)
+	staleToken, err := tokenService.NewToken(ctx, protocol.TO0Protocol)
+	if err != nil {
+		t.Fatalf("Failed to create token: %v", err)
+	}
+
+	// Verify session exists
+	var count int64
+	db.Model(&Session{}).Count(&count)
+	if count != 1 {
+		t.Fatalf("Expected 1 session, got %d", count)
+	}
+
+	// Manually update the session to be old
+	db.Model(&Session{}).Where("protocol = ?", protocol.TO0Protocol).
+		Update("created_at", time.Now().Add(-2*time.Hour))
+
+	// Create a fresh session
+	freshToken, err := tokenService.NewToken(ctx, protocol.TO1Protocol)
+	if err != nil {
+		t.Fatalf("Failed to create second token: %v", err)
+	}
+
+	// Verify both sessions exist
+	db.Model(&Session{}).Count(&count)
+	if count != 2 {
+		t.Fatalf("Expected 2 sessions, got %d", count)
+	}
+
+	// Cleanup sessions older than 1 hour
+	deletedCount, err := tokenService.CleanupExpiredSessions(ctx, 1*time.Hour)
+	if err != nil {
+		t.Fatalf("Cleanup failed: %v", err)
+	}
+	if deletedCount != 1 {
+		t.Fatalf("Expected 1 session to be deleted, got %d", deletedCount)
+	}
+
+	// Verify only the fresh session remains
+	db.Model(&Session{}).Count(&count)
+	if count != 1 {
+		t.Fatalf("Expected 1 session after cleanup, got %d", count)
+	}
+
+	// Verify the remaining session is the fresh one
+	var session Session
+	db.First(&session)
+	if session.Protocol != int(protocol.TO1Protocol) {
+		t.Fatalf("Remaining session has wrong protocol: %d", session.Protocol)
+	}
+
+	// Verify the stale token is invalid (session was deleted)
+	staleCtx := tokenService.TokenContext(ctx, staleToken)
+	_, err = tokenService.getSessionID(staleCtx)
+	if err == nil {
+		t.Fatal("Expected stale token to be invalid after cleanup")
+	}
+	if !errors.Is(err, fdo.ErrInvalidSession) {
+		t.Fatalf("Expected ErrInvalidSession for stale token, got: %v", err)
+	}
+
+	// Verify the fresh token is still valid
+	freshCtx := tokenService.TokenContext(ctx, freshToken)
+	sessionID, err := tokenService.getSessionID(freshCtx)
+	if err != nil {
+		t.Fatalf("Fresh token should be valid, got error: %v", err)
+	}
+	if sessionID == nil {
+		t.Fatal("Expected valid session ID for fresh token")
+	}
+}
+
+func TestSessionCreatedAtTimestamp(t *testing.T) {
+	db := setupTestTokenDB(t)
+	tokenService, err := InitTokenServiceDB(db)
+	if err != nil {
+		t.Fatalf("Failed to initialize token service DB: %v", err)
+	}
+
+	ctx := context.Background()
+
+	before := time.Now()
+	_, err = tokenService.NewToken(ctx, protocol.TO0Protocol)
+	if err != nil {
+		t.Fatalf("Failed to create token: %v", err)
+	}
+	after := time.Now()
+
+	// Verify the session has a created_at timestamp
+	var session Session
+	db.First(&session)
+
+	if session.CreatedAt.IsZero() {
+		t.Fatal("Session created_at is zero")
+	}
+
+	if session.CreatedAt.Before(before) || session.CreatedAt.After(after) {
+		t.Fatalf("Session created_at %v is outside expected range [%v, %v]",
+			session.CreatedAt, before, after)
+	}
+}


### PR DESCRIPTION
## Overview

  This PR implements automatic cleanup of expired rendezvous blobs and stale protocol sessions to prevent database bloat in production environments. The cleanup runs periodically in the background with configurable intervals and includes comprehensive metrics for monitoring.

## Problem

  The rendezvous server accumulates expired data over time:
  - Rendezvous blobs that have exceeded their expiration time
  - Protocol sessions (TO0/TO1) from interrupted or failed exchanges

  Without cleanup, this causes database bloat, degraded performance, and increased storage costs.

## Solution

  Implemented a comprehensive cleanup system with:
  - ✅ Periodic background cleanup task
  - ✅ Configurable cleanup intervals and thresholds
  - ✅ Graceful shutdown handling
  - ✅ Comprehensive metrics and logging
  - ✅ Database-agnostic implementation
  - ✅ Full test coverage

##  Key Features

### 1. Automatic Cleanup

  - Runs at configurable intervals (default: 1 hour)
  - Cleans up expired rendezvous blobs
  - Removes old sessions (default: older than 1 hour)
  - Can be disabled by setting cleanup_interval: 0

### 2. Startup Delay

  - Configurable initial delay before first cleanup (default: 5 minutes)
  - Prevents startup spikes when restarting with large amounts of expired data
  - Server starts serving requests immediately

###  3. Graceful Shutdown

  - Uses sync.WaitGroup to wait for in-progress cleanup
  - No data loss during server shutdown
  - Proper context cancellation

###  4. Metrics & Observability

  Structured logging includes:
  - Cleanup duration (milliseconds)
  - Blobs deleted count
  - Sessions deleted count
  - Total deletions
  - Error count

###  5. Database Improvements

  - Replaced fragile raw SQL with GORM constraint tags for CASCADE DELETE
  - Added indexed CreatedAt timestamp to sessions for efficient queries
  - Cross-database compatible (SQLite, PostgreSQL, MySQL)

## Configuration Options

  Via Config File (YAML/TOML)
```yaml
  rendezvous:
    cleanup_interval: 3600         # Run cleanup every hour (default)
    session_timeout: 3600          # Delete sessions older than 1 hour (default)
    initial_cleanup_delay: 300     # Wait 5 minutes before first cleanup (default)
```
  Via CLI Flags
```bash
  go-fdo-server rendezvous \
    --cleanup-interval 3600 \
    --session-timeout 3600 \
    --initial-cleanup-delay 300
```

## Testing

  Added comprehensive test coverage:
  - ✅ TestCleanupExpiredBlobs - Verifies blob cleanup logic
  - ✅ TestCleanupExpiredSessions - Tests session cleanup by age
  - ✅ TestSessionCreatedAtTimestamp - Validates timestamp handling

  All tests use in-memory databases for fast execution.

##  Documentation

  - Updated CONFIG.md with complete configuration reference
  - Updated configs/rendezvous.yaml with inline documentation
  - CLI help text includes all new flags

Closes #177 