### PR TITLE
fix: remove Device CA lines from RV bypass test and add to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,3 +380,32 @@ jobs:
         run: |
           source test/ci/test-device-ca-rendezvous-trust.sh
           cleanup
+
+  test-rv-bypass:
+    name: Test RV bypass (direct device to owner)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install golang
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Test RV bypass
+        run: |
+          source test/ci/test-rv-bypass.sh
+          run_test
+
+      - name: Get manufacturer and owner server logs
+        if: always()
+        run: |
+          source test/ci/test-rv-bypass.sh
+          get_logs
+
+      - name: Cleanup the environment
+        if: always()
+        run: |
+          source test/ci/test-rv-bypass.sh
+          cleanup

--- a/test/ci/test-rv-bypass.sh
+++ b/test/ci/test-rv-bypass.sh
@@ -39,9 +39,6 @@ run_test() {
   rv_info="[{\"dns\": \"${owner_dns}\", \"device_port\": \"${owner_port}\", \"protocol\": \"${owner_protocol}\", \"ip\": \"${owner_ip}\", \"owner_port\": \"${owner_port}\", \"rv_bypass\": true}]"
   set_or_update_rendezvous_info "${manufacturer_url}" "${rv_info}"
 
-  log_info "Adding Device CA certificate to rendezvous"
-  add_device_ca_cert "${rendezvous_url}" "${device_ca_crt}" | jq -r -M .
-
   log_info "Run Device Initialization"
   guid=$(run_device_initialization)
   log_info "Device initialized with GUID: ${guid}"


### PR DESCRIPTION
## Summary
- Remove Device CA certificate addition to rendezvous server in `test-rv-bypass.sh`
- Add `test-rv-bypass` job to CI workflow (`.github/workflows/ci.yml`)

## Problem
The RV bypass test was failing because it attempted to add a Device CA certificate to the rendezvous server, which is not started in this test scenario. The rendezvous server is intentionally excluded because RV bypass means devices connect directly to the Owner, skipping the rendezvous/TO1 phase entirely.

This issue was not caught earlier because the test was missing from the CI workflow.

## Changes
1. **`test/ci/test-rv-bypass.sh`**: Removed lines 42-43 that attempted to configure the non-existent rendezvous server
2. **`.github/workflows/ci.yml`**: Added new `test-rv-bypass` job to run this test on every PR and push to main

## Testing
- Ran test locally: `./test/ci/test-rv-bypass.sh` ✅
- Test now passes without errors
- Device successfully onboards via RV bypass (skips TO1, direct TO2 to Owner)

## Verification
```
[11:39:57] INFO: RV bypass enabled, skipping TO1 protocol
[11:39:57] INFO: Using Owner URL from bypass directive
[11:39:57] INFO: TO2 succeeded
[11:39:57] INFO: FIDO Device Onboard Complete
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)