### PR TITLE
fix: update RV bypass test and add to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,3 +380,32 @@ jobs:
         run: |
           source test/ci/test-device-ca-rendezvous-trust.sh
           cleanup
+
+  test-rv-bypass:
+    name: Test RV bypass
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install golang
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Test RV bypass
+        run: |
+          source test/ci/test-rv-bypass.sh
+          run_test
+
+      - name: Get manufacturer and owner server logs
+        if: always()
+        run: |
+          source test/ci/test-rv-bypass.sh
+          get_logs
+
+      - name: Cleanup the environment
+        if: always()
+        run: |
+          source test/ci/test-rv-bypass.sh
+          cleanup

--- a/test/ci/test-rv-bypass.sh
+++ b/test/ci/test-rv-bypass.sh
@@ -39,9 +39,6 @@ run_test() {
   rv_info="[{\"dns\": \"${owner_dns}\", \"device_port\": \"${owner_port}\", \"protocol\": \"${owner_protocol}\", \"ip\": \"${owner_ip}\", \"owner_port\": \"${owner_port}\", \"rv_bypass\": true}]"
   set_or_update_rendezvous_info "${manufacturer_url}" "${rv_info}"
 
-  log_info "Adding Device CA certificate to rendezvous"
-  add_device_ca_cert "${rendezvous_url}" "${device_ca_crt}" | jq -r -M .
-
   log_info "Run Device Initialization"
   guid=$(run_device_initialization)
   log_info "Device initialized with GUID: ${guid}"


### PR DESCRIPTION
- Remove Device CA certificate addition to rendezvous in test-rv-bypass.sh (rendezvous server is not started in RV bypass test)
- Add test-rv-bypass job to CI workflow
- Test was previously missing from CI, allowing this issue to go undetected