### PR TITLE
docs: add man page generation tool and improve CLI descriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ go-fdo-server-*.tar.*
 rpmbuild
 test/workdir
 test/coverage
+/docgen

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -79,43 +79,43 @@ provided under the `[http]` section:
 
 ## Device CA Configuration
 
-The Device Certificate Authority configuration is under the `[device_ca]` section. This section is required for both manufacturing and owner servers:
+The Device Certificate Authority configuration is under the `[device_ca]` section. This section is required for both Manufacturing and Owner servers:
 
 | Key | Type | Description | Required |
 |-----|------|-------------|----------|
 | `cert` | string | Device CA certificate file path | Yes |
-| `key` | string | Device CA private key file path | Yes (for manufacturing server) |
+| `key` | string | Device CA private key file path | Yes (for Manufacturing server) |
 
-**Note**: For the owner server, only the `cert` field is required. The `key` field is only needed for the manufacturing server.
+**Note**: For the Owner server, only the `cert` field is required. The `key` field is only needed for the Manufacturing server.
 
 ## Manufacturing Server Configuration
 
-The manufacturing server configuration is under the `[manufacturing]` section:
+The Manufacturing server configuration is under the `[manufacturing]` section:
 
 | Key | Type | Description | Required |
 |-----|------|-------------|----------|
 | `key` | string | Manufacturing private key file path | Yes |
 
-The manufacturing server also requires:
+The Manufacturing server also requires:
 - `[device_ca]` section with both `cert` and `key` (see Device CA Configuration above)
 - `[owner]` section with `cert` field (see Owner Configuration below)
 
 ## Owner Server Configuration
 
-The owner server configuration is under the `[owner]` section:
+The Owner server configuration is under the `[owner]` section:
 
 | Key | Type | Description | Required |
 |-----|------|-------------|----------|
-| `cert` | string | Owner certificate file path | Yes (for manufacturing server) |
-| `key` | string | Owner private key file path | Yes (for owner server) |
+| `cert` | string | Owner certificate file path | Yes (for Manufacturing server) |
+| `key` | string | Owner private key file path | Yes (for Owner server) |
 | `reuse_credentials` | boolean | Perform the Credential Reuse Protocol in TO2 | No (default: false) |
 | `to0_insecure_tls` | boolean | Skip TLS certificate verification for TO0 | No (default: false) |
 | `service_info` | map | ServiceInfo Modules to execute on device onboarding (See below) | No |
 
-The owner server also requires:
+The Owner server also requires:
 - `[device_ca]` section with `cert` field (see Device CA Configuration above)
 
-**Note**: The `owner.cert` field is used by the manufacturing server to specify the owner certificate. The `owner.key` field is used by the owner server to specify its private key.
+**Note**: The `owner.cert` field is used by the Manufacturing server to specify the Owner certificate. The `owner.key` field is used by the Owner server to specify its private key.
 
 ### Service Info Configuration (FSIM Operations)
 
@@ -316,17 +316,17 @@ For the example above the first download will be saved to `/tmp/app.rpm`, the se
 
 ## Rendezvous Server Configuration
 
-The rendezvous server configuration is under the `[rendezvous]` section:
+The Rendezvous server configuration is under the `[rendezvous]` section:
 
 | Key | Type | Description | Default |
 |-----|------|-------------|---------|
-| `to0_min_wait` | integer | Minimum wait time in seconds for TO0 rendezvous entries. Requests below this value are rejected. Set to 0 for no minimum. | 0 |
-| `to0_max_wait` | integer | Maximum wait time in seconds for TO0 rendezvous entries. Requests above this value are accepted but capped at this maximum. This prevents owner servers from registering rendezvous blobs for excessively long periods. | 86400 (24 hours) |
+| `to0_min_wait` | integer | Minimum wait time the Rendezvous server will accept for an entry registered by the Owner server during TO0 protocol. If the Owner server requests a shorter wait time, it is rejected. | 0 (no minimum) |
+| `to0_max_wait` | integer | Maximum wait time the Rendezvous server will keep an entry registered by the Owner server during TO0 protocol before it expires. If the Owner server requests a longer wait time, it is capped to this value. | 86400 (24 hours) |
 | `cleanup_interval` | integer | Interval in seconds for automatic cleanup of expired rendezvous blobs and sessions. The cleanup task runs periodically in the background, removing rendezvous blobs that have exceeded their expiration time and sessions older than `session_timeout` to prevent database bloat. Set to 0 to disable automatic cleanup (not recommended for production). | 3600 (1 hour) |
 | `session_timeout` | integer | Maximum age in seconds for protocol sessions (TO0/TO1) before cleanup. Sessions older than this age will be deleted during periodic cleanup, along with their associated session data. This prevents accumulation of orphaned sessions from interrupted or failed protocol exchanges. | 3600 (1 hour) |
 | `initial_cleanup_delay` | integer | Delay in seconds before the first cleanup runs after server startup. This prevents startup spikes when restarting servers with large amounts of expired data, allowing the server to start serving requests before running potentially heavy cleanup operations. | 300 (5 minutes) |
 
-**Note**: The rendezvous server performs periodic background cleanup to prevent database bloat. Expired rendezvous blobs and old sessions are automatically removed based on the configured intervals.
+**Note**: The Rendezvous server performs periodic background cleanup to prevent database bloat. Expired rendezvous blobs and old sessions are automatically removed based on the configured intervals.
 
 ## Configuration File Examples
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ all: build test
 
 # Build the Go project
 .PHONY: build
-build: generate tidy fmt vet
+build: generate tidy fmt vet man
 	go build $(GOFLAGS) -ldflags="-X github.com/fido-device-onboard/go-fdo-server/internal/version.VERSION=${VERSION}"
 
 .PHONY: oapi-codegen
@@ -48,6 +48,10 @@ vet:
 .PHONY: test
 test:
 	go test -v ./...
+
+.PHONY: man
+man:
+	go run ./internal/tools/docgen -format man
 
 .PHONY: shfmt
 shfmt:

--- a/api/manufacturer/openapi.yaml
+++ b/api/manufacturer/openapi.yaml
@@ -50,7 +50,7 @@ info:
     When rate limits are exceeded, the API returns a 429 Too Many Requests status code.
   contact:
     name: Go FDO Server API Support
-    url: 'https://github.com/fido-device-onboard/go-fdo-server/issues'
+    url: https://github.com/fido-device-onboard/go-fdo-server/issues
 paths:
   /health:
     get:
@@ -110,7 +110,7 @@ paths:
           schema:
             type: string
             example: d21d841a3f54f4e89a60ed9b9779e9e8
-            pattern: '^[a-f0-9]{32}$'
+            pattern: ^[a-f0-9]{32}$
         - name: deviceInfo
           in: query
           description: Filters the results by device information (case-insensitive partial match).
@@ -171,15 +171,15 @@ paths:
                           protocolVersion: 101
                           deviceInfo: Intel Device
                           numEntries: 1
-                        createdAt: '2025-05-10T10:30:00Z'
-                        updatedAt: '2025-05-10T10:30:00Z'
+                        createdAt: 2025-05-10T10:30:00Z
+                        updatedAt: 2025-05-10T10:30:00Z
                       - voucher:
                           guid: a1b2c3d4e5f6789012345678abcdef01
                           protocolVersion: 101
                           deviceInfo: ARM IoT Device
                           numEntries: 2
-                        createdAt: '2025-06-20T12:00:00Z'
-                        updatedAt: '2025-06-21T08:15:00Z'
+                        createdAt: 2025-06-20T12:00:00Z
+                        updatedAt: 2025-06-21T08:15:00Z
             application/x-pem-file:
               schema:
                 type: string
@@ -262,15 +262,15 @@ paths:
                         protocolVersion: 101
                         deviceInfo: Intel Device
                         numEntries: 1
-                      createdAt: '2025-10-27T14:00:00Z'
-                      updatedAt: '2025-10-27T14:00:00Z'
+                      createdAt: 2025-10-27T14:00:00Z
+                      updatedAt: 2025-10-27T14:00:00Z
                     - voucher:
                         guid: a1b2c3d4e5f6789012345678abcdef01
                         protocolVersion: 101
                         deviceInfo: ARM IoT Device
                         numEntries: 1
-                      createdAt: '2025-10-27T14:00:00Z'
-                      updatedAt: '2025-10-27T14:00:00Z'
+                      createdAt: 2025-10-27T14:00:00Z
+                      updatedAt: 2025-10-27T14:00:00Z
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -287,7 +287,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
       tags:
         - voucher
-  '/v1/vouchers/{guid}':
+  /v1/vouchers/{guid}:
     get:
       operationId: GetOwnershipVoucherByGuid
       summary: Get an ownership voucher by GUID
@@ -307,7 +307,7 @@ paths:
           schema:
             type: string
             example: d21d841a3f54f4e89a60ed9b9779e9e8
-            pattern: '^[a-f0-9]{32}$'
+            pattern: ^[a-f0-9]{32}$
       responses:
         '200':
           description: The requested ownership voucher.
@@ -341,7 +341,7 @@ paths:
                       algorithm: HMAC-SHA-384
                       value: e5f6a7b8...
                     certChain:
-                      - '-----BEGIN CERTIFICATE-----\nMIID...\n-----END CERTIFICATE-----'
+                      - -----BEGIN CERTIFICATE-----\nMIID...\n-----END CERTIFICATE-----
                     entries:
                       - previousHash:
                           algorithm: SHA-384
@@ -389,7 +389,7 @@ paths:
           schema:
             type: string
             example: d21d841a3f54f4e89a60ed9b9779e9e8
-            pattern: '^[a-f0-9]{32}$'
+            pattern: ^[a-f0-9]{32}$
       responses:
         '204':
           description: Ownership voucher deleted successfully.
@@ -403,7 +403,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
       tags:
         - voucher
-  '/v1/vouchers/{guid}/extend':
+  /v1/vouchers/{guid}/extend:
     post:
       operationId: ExtendOwnershipVoucher
       summary: Extend an ownership voucher
@@ -421,7 +421,7 @@ paths:
           schema:
             type: string
             example: d21d841a3f54f4e89a60ed9b9779e9e8
-            pattern: '^[a-f0-9]{32}$'
+            pattern: ^[a-f0-9]{32}$
       requestBody:
         description: New owner's public key or certificate in PEM format.
         required: true
@@ -720,9 +720,9 @@ components:
       description: The device GUID (32 hexadecimal characters).
       type: string
       example: d21d841a3f54f4e89a60ed9b9779e9e8
-      pattern: '^[a-f0-9]{32}$'
+      pattern: ^[a-f0-9]{32}$
     VoucherProtocolVersion:
-      description: 'The FDO protocol version (e.g., 101 for version 1.1).'
+      description: The FDO protocol version (e.g., 101 for version 1.1).
       type: integer
       example: 101
     VoucherDeviceInfo:
@@ -959,7 +959,7 @@ components:
       properties:
         sv_cert_hash:
           type: string
-          pattern: '^[a-fA-F0-9]{64}$|^[a-fA-F0-9]{96}$'
+          pattern: ^[a-fA-F0-9]{64}$|^[a-fA-F0-9]{96}$
       example:
         sv_cert_hash: a1b2c3d4e5f6789012345678abcdef0123456789abcdef0123456789abcdef01
     ClCertHash:
@@ -968,7 +968,7 @@ components:
       properties:
         cl_cert_hash:
           type: string
-          pattern: '^[a-fA-F0-9]{64}$|^[a-fA-F0-9]{96}$'
+          pattern: ^[a-fA-F0-9]{64}$|^[a-fA-F0-9]{96}$
       example:
         cl_cert_hash: b2c3d4e5f6a78901234567890abcdef1b2c3d4e5f6a78901234567890abcdef1
     UserInput:
@@ -1070,7 +1070,7 @@ components:
             - SHA-512/HMAC-SHA-512: 128 hexadecimal characters (64 bytes)
           type: string
           example: a1b2c3d4e5f6789012345678abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef01
-          pattern: '^[a-fA-F0-9]{64}$|^[a-fA-F0-9]{96}$|^[a-fA-F0-9]{128}$'
+          pattern: ^[a-fA-F0-9]{64}$|^[a-fA-F0-9]{96}$|^[a-fA-F0-9]{128}$
       required:
         - algorithm
         - value
@@ -1085,7 +1085,7 @@ components:
           description: The device GUID (32 hexadecimal characters).
           type: string
           example: d21d841a3f54f4e89a60ed9b9779e9e8
-          pattern: '^[a-f0-9]{32}$'
+          pattern: ^[a-f0-9]{32}$
         rvInfo:
           $ref: '#/components/schemas/RVInfo'
         deviceInfo:
@@ -1197,7 +1197,7 @@ components:
               value:
                 message: Invalid Request.
     Unauthorized:
-      description: 'Unauthorized - Authentication credentials missing, invalid, or expired.'
+      description: Unauthorized - Authentication credentials missing, invalid, or expired.
       content:
         application/json:
           schema:

--- a/api/owner/openapi.yaml
+++ b/api/owner/openapi.yaml
@@ -51,7 +51,7 @@ info:
     When rate limits are exceeded, the API returns a 429 Too Many Requests status code.
   contact:
     name: Go FDO Server API Support
-    url: 'https://github.com/fido-device-onboard/go-fdo-server/issues'
+    url: https://github.com/fido-device-onboard/go-fdo-server/issues
 paths:
   /health:
     get:
@@ -111,7 +111,7 @@ paths:
           schema:
             type: string
             example: d21d841a3f54f4e89a60ed9b9779e9e8
-            pattern: '^[a-f0-9]{32}$'
+            pattern: ^[a-f0-9]{32}$
         - name: deviceInfo
           in: query
           description: Filters the results by device information (case-insensitive partial match).
@@ -172,15 +172,15 @@ paths:
                           protocolVersion: 101
                           deviceInfo: Intel Device
                           numEntries: 1
-                        createdAt: '2025-05-10T10:30:00Z'
-                        updatedAt: '2025-05-10T10:30:00Z'
+                        createdAt: 2025-05-10T10:30:00Z
+                        updatedAt: 2025-05-10T10:30:00Z
                       - voucher:
                           guid: a1b2c3d4e5f6789012345678abcdef01
                           protocolVersion: 101
                           deviceInfo: ARM IoT Device
                           numEntries: 2
-                        createdAt: '2025-06-20T12:00:00Z'
-                        updatedAt: '2025-06-21T08:15:00Z'
+                        createdAt: 2025-06-20T12:00:00Z
+                        updatedAt: 2025-06-21T08:15:00Z
             application/x-pem-file:
               schema:
                 type: string
@@ -263,15 +263,15 @@ paths:
                         protocolVersion: 101
                         deviceInfo: Intel Device
                         numEntries: 1
-                      createdAt: '2025-10-27T14:00:00Z'
-                      updatedAt: '2025-10-27T14:00:00Z'
+                      createdAt: 2025-10-27T14:00:00Z
+                      updatedAt: 2025-10-27T14:00:00Z
                     - voucher:
                         guid: a1b2c3d4e5f6789012345678abcdef01
                         protocolVersion: 101
                         deviceInfo: ARM IoT Device
                         numEntries: 1
-                      createdAt: '2025-10-27T14:00:00Z'
-                      updatedAt: '2025-10-27T14:00:00Z'
+                      createdAt: 2025-10-27T14:00:00Z
+                      updatedAt: 2025-10-27T14:00:00Z
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -288,7 +288,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
       tags:
         - voucher
-  '/v1/vouchers/{guid}':
+  /v1/vouchers/{guid}:
     get:
       operationId: GetOwnershipVoucherByGuid
       summary: Get an ownership voucher by GUID
@@ -308,7 +308,7 @@ paths:
           schema:
             type: string
             example: d21d841a3f54f4e89a60ed9b9779e9e8
-            pattern: '^[a-f0-9]{32}$'
+            pattern: ^[a-f0-9]{32}$
       responses:
         '200':
           description: The requested ownership voucher.
@@ -342,7 +342,7 @@ paths:
                       algorithm: HMAC-SHA-384
                       value: e5f6a7b8...
                     certChain:
-                      - '-----BEGIN CERTIFICATE-----\nMIID...\n-----END CERTIFICATE-----'
+                      - -----BEGIN CERTIFICATE-----\nMIID...\n-----END CERTIFICATE-----
                     entries:
                       - previousHash:
                           algorithm: SHA-384
@@ -390,7 +390,7 @@ paths:
           schema:
             type: string
             example: d21d841a3f54f4e89a60ed9b9779e9e8
-            pattern: '^[a-f0-9]{32}$'
+            pattern: ^[a-f0-9]{32}$
       responses:
         '204':
           description: Ownership voucher deleted successfully.
@@ -404,7 +404,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
       tags:
         - voucher
-  '/v1/vouchers/{guid}/extend':
+  /v1/vouchers/{guid}/extend:
     post:
       operationId: ExtendOwnershipVoucher
       summary: Extend an ownership voucher
@@ -422,7 +422,7 @@ paths:
           schema:
             type: string
             example: d21d841a3f54f4e89a60ed9b9779e9e8
-            pattern: '^[a-f0-9]{32}$'
+            pattern: ^[a-f0-9]{32}$
       requestBody:
         description: New owner's public key or certificate in PEM format.
         required: true
@@ -517,14 +517,14 @@ paths:
           required: false
           schema:
             type: string
-            example: 'CN=Example Device CA, O=Example Inc, C=US'
+            example: CN=Example Device CA, O=Example Inc, C=US
         - name: subject
           in: query
           description: Filters the results by the exact subject distinguished name.
           required: false
           schema:
             type: string
-            example: 'CN=Example Device CA, O=Example Inc, C=US'
+            example: CN=Example Device CA, O=Example Inc, C=US
         - name: validityStatus
           in: query
           description: Filters certificates by their validity status.
@@ -584,21 +584,21 @@ paths:
                           -----BEGIN CERTIFICATE-----
                           MIID... (truncated) 
                           -----END CERTIFICATE-----
-                        subject: 'CN=Example Device CA One, O=Example Corp, C=US'
-                        issuer: 'CN=Example Intermediate CA, O=Example Corp, C=US'
-                        notBefore: '2025-01-01T00:00:00Z'
-                        notAfter: '2026-01-01T00:00:00Z'
-                        createdAt: '2025-05-10T10:30:00Z'
+                        subject: CN=Example Device CA One, O=Example Corp, C=US
+                        issuer: CN=Example Intermediate CA, O=Example Corp, C=US
+                        notBefore: 2025-01-01T00:00:00Z
+                        notAfter: 2026-01-01T00:00:00Z
+                        createdAt: 2025-05-10T10:30:00Z
                       - fingerprint: b2c3d4e5f6a78901234567890abcdef1b2c3d4e5f6a78901234567890abcdef1
                         pem: |
                           -----BEGIN CERTIFICATE-----
                           MIID... (truncated) 
                           -----END CERTIFICATE-----
-                        subject: 'CN=Example Device CA Two, O=Example Corp, C=US'
-                        issuer: 'CN=Example Intermediate CA, O=Example Corp, C=US'
-                        notBefore: '2025-02-15T00:00:00Z'
-                        notAfter: '2026-02-15T00:00:00Z'
-                        createdAt: '2025-06-20T12:00:00Z'
+                        subject: CN=Example Device CA Two, O=Example Corp, C=US
+                        issuer: CN=Example Intermediate CA, O=Example Corp, C=US
+                        notBefore: 2025-02-15T00:00:00Z
+                        notAfter: 2026-02-15T00:00:00Z
+                        createdAt: 2025-06-20T12:00:00Z
             application/x-pem-file:
               schema:
                 type: string
@@ -678,31 +678,31 @@ paths:
                     skipped: 0
                     malformed: 0
                     messages:
-                      - 'the certificate at position 1 with subject ''CN=Example Device CA One, O=Example Corp, C=US'' was imported successfully'
-                      - 'the certificate at position 2 with subject ''CN=Example Device CA Two, O=Example Corp, C=US'' was imported successfully'
+                      - the certificate at position 1 with subject 'CN=Example Device CA One, O=Example Corp, C=US' was imported successfully
+                      - the certificate at position 2 with subject 'CN=Example Device CA Two, O=Example Corp, C=US' was imported successfully
                     certs:
                       - fingerprint: c3d4e5f6a7b890123456789abcdef012c3d4e5f6a7b890123456789abcdef012
                         pem: |
                           -----BEGIN CERTIFICATE-----
                           MIID... (truncated) 
                           -----END CERTIFICATE-----
-                        subject: 'CN=Example Device CA One, O=Example Corp, C=US'
-                        issuer: 'CN=Example Intermediate CA, O=Example Corp, C=US'
-                        notBefore: '2025-10-01T00:00:00Z'
-                        notAfter: '2026-10-01T00:00:00Z'
-                        createdAt: '2025-10-27T14:00:00Z'
+                        subject: CN=Example Device CA One, O=Example Corp, C=US
+                        issuer: CN=Example Intermediate CA, O=Example Corp, C=US
+                        notBefore: 2025-10-01T00:00:00Z
+                        notAfter: 2026-10-01T00:00:00Z
+                        createdAt: 2025-10-27T14:00:00Z
                       - fingerprint: d4e5f6a7b8c901234567890abcdef123d4e5f6a7b8c901234567890abcdef123
                         pem: |
                           -----BEGIN CERTIFICATE-----
                           MIID... (truncated) 
                           -----END CERTIFICATE-----
-                        subject: 'CN=Example Device CA Two, O=Example Corp, C=US'
-                        issuer: 'CN=Example Intermediate CA, O=Example Corp, C=US'
-                        notBefore: '2025-10-01T00:00:00Z'
-                        notAfter: '2026-10-01T00:00:00Z'
-                        createdAt: '2025-10-27T14:00:00Z'
+                        subject: CN=Example Device CA Two, O=Example Corp, C=US
+                        issuer: CN=Example Intermediate CA, O=Example Corp, C=US
+                        notBefore: 2025-10-01T00:00:00Z
+                        notAfter: 2026-10-01T00:00:00Z
+                        createdAt: 2025-10-27T14:00:00Z
                 partialImport:
-                  summary: 'Some certificates skipped (duplicates, expired or malformed)'
+                  summary: Some certificates skipped (duplicates, expired or malformed)
                   value:
                     detected: 4
                     imported: 2
@@ -710,30 +710,30 @@ paths:
                     malformed: 1
                     messages:
                       - the certificate at position 1 is malformed
-                      - 'the certificate at position 2 with subject ''CN=Example Device CA One, O=Example Corp, C=US'' was imported successfully'
-                      - 'the certificate at position 3 with subject ''CN=Example Device CA Expired, O=Example Corp, C=US'' was skipped because it is expired'
-                      - 'the certificate at position 4 with subject ''CN=Example Device CA Two, O=Example Corp, C=US'' was imported successfully'
+                      - the certificate at position 2 with subject 'CN=Example Device CA One, O=Example Corp, C=US' was imported successfully
+                      - the certificate at position 3 with subject 'CN=Example Device CA Expired, O=Example Corp, C=US' was skipped because it is expired
+                      - the certificate at position 4 with subject 'CN=Example Device CA Two, O=Example Corp, C=US' was imported successfully
                     certs:
                       - fingerprint: c3d4e5f6a7b890123456789abcdef012c3d4e5f6a7b890123456789abcdef012
                         pem: |
                           -----BEGIN CERTIFICATE-----
                           MIID... (truncated) 
                           -----END CERTIFICATE-----
-                        subject: 'CN=Example Device CA One, O=Example Corp, C=US'
-                        issuer: 'CN=Example Intermediate CA, O=Example Corp, C=US'
-                        notBefore: '2025-10-01T00:00:00Z'
-                        notAfter: '2026-10-01T00:00:00Z'
-                        createdAt: '2025-10-27T14:00:00Z'
+                        subject: CN=Example Device CA One, O=Example Corp, C=US
+                        issuer: CN=Example Intermediate CA, O=Example Corp, C=US
+                        notBefore: 2025-10-01T00:00:00Z
+                        notAfter: 2026-10-01T00:00:00Z
+                        createdAt: 2025-10-27T14:00:00Z
                       - fingerprint: d4e5f6a7b8c901234567890abcdef123d4e5f6a7b8c901234567890abcdef123
                         pem: |
                           -----BEGIN CERTIFICATE-----
                           MIID... (truncated) 
                           -----END CERTIFICATE-----
-                        subject: 'CN=Example Device CA Two, O=Example Corp, C=US'
-                        issuer: 'CN=Example Intermediate CA, O=Example Corp, C=US'
-                        notBefore: '2025-10-01T00:00:00Z'
-                        notAfter: '2026-10-01T00:00:00Z'
-                        createdAt: '2025-10-27T14:00:00Z'
+                        subject: CN=Example Device CA Two, O=Example Corp, C=US
+                        issuer: CN=Example Intermediate CA, O=Example Corp, C=US
+                        notBefore: 2025-10-01T00:00:00Z
+                        notAfter: 2026-10-01T00:00:00Z
+                        createdAt: 2025-10-27T14:00:00Z
                 noneImported:
                   summary: All certificates already exist
                   value:
@@ -742,8 +742,8 @@ paths:
                     skipped: 2
                     malformed: 0
                     messages:
-                      - 'the certificate at position 1 with subject ''CN=Example Device CA One, O=Example Corp, C=US'' was skipped because it already exists'
-                      - 'the certificate at position 2 with subject ''CN=Example Device CA Two, O=Example Corp, C=US'' was skipped because it already exists'
+                      - the certificate at position 1 with subject 'CN=Example Device CA One, O=Example Corp, C=US' was skipped because it already exists
+                      - the certificate at position 2 with subject 'CN=Example Device CA Two, O=Example Corp, C=US' was skipped because it already exists
                     certs: []
         '400':
           $ref: '#/components/responses/BadRequest'
@@ -761,7 +761,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
       tags:
         - device-ca
-  '/v1/device-ca/{fingerprint}':
+  /v1/device-ca/{fingerprint}:
     get:
       operationId: GetTrustedDeviceCACertByFingerprint
       summary: Get a trusted device CA certificate by fingerprint
@@ -779,7 +779,7 @@ paths:
           schema:
             type: string
             example: a1b2c3d4e5f67890123456789abcdef0a1b2c3d4e5f67890123456789abcdef0
-            pattern: '^[a-f0-9]{64}$'
+            pattern: ^[a-f0-9]{64}$
       responses:
         '200':
           description: The requested trusted device CA certificate.
@@ -796,11 +796,11 @@ paths:
                       -----BEGIN CERTIFICATE-----
                       MIID... (truncated) 
                       -----END CERTIFICATE-----
-                    subject: 'CN=Example Device CA, O=Example Corp, C=US'
-                    issuer: 'CN=Example Intermediate CA, O=Example Corp, C=US'
-                    notBefore: '2025-01-01T00:00:00Z'
-                    notAfter: '2026-01-01T00:00:00Z'
-                    createdAt: '2025-05-10T10:30:00Z'
+                    subject: CN=Example Device CA, O=Example Corp, C=US
+                    issuer: CN=Example Intermediate CA, O=Example Corp, C=US
+                    notBefore: 2025-01-01T00:00:00Z
+                    notAfter: 2026-01-01T00:00:00Z
+                    createdAt: 2025-05-10T10:30:00Z
             application/x-pem-file:
               schema:
                 description: The certificate content in PEM format.
@@ -835,7 +835,7 @@ paths:
           schema:
             type: string
             example: a1b2c3d4e5f67890123456789abcdef0a1b2c3d4e5f67890123456789abcdef0
-            pattern: '^[a-f0-9]{64}$'
+            pattern: ^[a-f0-9]{64}$
       responses:
         '204':
           description: Trusted device CA certificate deleted successfully.
@@ -1069,9 +1069,9 @@ components:
       description: The device GUID (32 hexadecimal characters).
       type: string
       example: d21d841a3f54f4e89a60ed9b9779e9e8
-      pattern: '^[a-f0-9]{32}$'
+      pattern: ^[a-f0-9]{32}$
     VoucherProtocolVersion:
-      description: 'The FDO protocol version (e.g., 101 for version 1.1).'
+      description: The FDO protocol version (e.g., 101 for version 1.1).
       type: integer
       example: 101
     VoucherDeviceInfo:
@@ -1308,7 +1308,7 @@ components:
       properties:
         sv_cert_hash:
           type: string
-          pattern: '^[a-fA-F0-9]{64}$|^[a-fA-F0-9]{96}$'
+          pattern: ^[a-fA-F0-9]{64}$|^[a-fA-F0-9]{96}$
       example:
         sv_cert_hash: a1b2c3d4e5f6789012345678abcdef0123456789abcdef0123456789abcdef01
     ClCertHash:
@@ -1317,7 +1317,7 @@ components:
       properties:
         cl_cert_hash:
           type: string
-          pattern: '^[a-fA-F0-9]{64}$|^[a-fA-F0-9]{96}$'
+          pattern: ^[a-fA-F0-9]{64}$|^[a-fA-F0-9]{96}$
       example:
         cl_cert_hash: b2c3d4e5f6a78901234567890abcdef1b2c3d4e5f6a78901234567890abcdef1
     UserInput:
@@ -1419,7 +1419,7 @@ components:
             - SHA-512/HMAC-SHA-512: 128 hexadecimal characters (64 bytes)
           type: string
           example: a1b2c3d4e5f6789012345678abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef01
-          pattern: '^[a-fA-F0-9]{64}$|^[a-fA-F0-9]{96}$|^[a-fA-F0-9]{128}$'
+          pattern: ^[a-fA-F0-9]{64}$|^[a-fA-F0-9]{96}$|^[a-fA-F0-9]{128}$
       required:
         - algorithm
         - value
@@ -1434,7 +1434,7 @@ components:
           description: The device GUID (32 hexadecimal characters).
           type: string
           example: d21d841a3f54f4e89a60ed9b9779e9e8
-          pattern: '^[a-f0-9]{32}$'
+          pattern: ^[a-f0-9]{32}$
         rvInfo:
           $ref: '#/components/schemas/RVInfo'
         deviceInfo:
@@ -1516,13 +1516,13 @@ components:
           description: The SHA-256 fingerprint of the certificate (64 hexadecimal characters).
           type: string
           example: a1b2c3d4e5f67890123456789abcdef0a1b2c3d4e5f67890123456789abcdef0
-          pattern: '^[a-f0-9]{64}$'
+          pattern: ^[a-f0-9]{64}$
         pem:
           description: The full certificate content in PEM format.
           type: string
           format: pem
           maxLength: 32768
-          pattern: '^-----BEGIN CERTIFICATE-----\n[\s\S]+\n-----END CERTIFICATE-----\n?$'
+          pattern: ^-----BEGIN CERTIFICATE-----\n[\s\S]+\n-----END CERTIFICATE-----\n?$
         subject:
           description: The subject distinguished name of the certificate.
           type: string
@@ -1598,12 +1598,12 @@ components:
             type: string
           example:
             - the certificate at position 1 is malformed
-            - 'the certificate at position 2 with subject ''CN=Device CA 2,O=Example Inc'' was imported successfully'
-            - 'the certificate at position 3 with subject ''CN=Device CA 3,O=Example Inc'' was skipped because it is expired'
-            - 'the certificate at position 4 with subject ''CN=Device CA 4,O=Example Inc'' was skipped because it already exists'
-            - 'the certificate at position 5 with subject ''CN=Device CA 5,O=Example Inc'' was imported successfully'
+            - the certificate at position 2 with subject 'CN=Device CA 2,O=Example Inc' was imported successfully
+            - the certificate at position 3 with subject 'CN=Device CA 3,O=Example Inc' was skipped because it is expired
+            - the certificate at position 4 with subject 'CN=Device CA 4,O=Example Inc' was skipped because it already exists
+            - the certificate at position 5 with subject 'CN=Device CA 5,O=Example Inc' was imported successfully
         certs:
-          description: 'Array of certificates that were successfully imported (does not include malformed, expired or already existing certificates).'
+          description: Array of certificates that were successfully imported (does not include malformed, expired or already existing certificates).
           type: array
           items:
             $ref: '#/components/schemas/TrustedDeviceCACert'
@@ -1688,7 +1688,7 @@ components:
               value:
                 message: Invalid Request.
     Unauthorized:
-      description: 'Unauthorized - Authentication credentials missing, invalid, or expired.'
+      description: Unauthorized - Authentication credentials missing, invalid, or expired.
       content:
         application/json:
           schema:

--- a/api/rendezvous/openapi.yaml
+++ b/api/rendezvous/openapi.yaml
@@ -49,7 +49,7 @@ info:
     When rate limits are exceeded, the API returns a 429 Too Many Requests status code.
   contact:
     name: Go FDO Server API Support
-    url: 'https://github.com/fido-device-onboard/go-fdo-server/issues'
+    url: https://github.com/fido-device-onboard/go-fdo-server/issues
 paths:
   /health:
     get:
@@ -106,14 +106,14 @@ paths:
           required: false
           schema:
             type: string
-            example: 'CN=Example Device CA, O=Example Inc, C=US'
+            example: CN=Example Device CA, O=Example Inc, C=US
         - name: subject
           in: query
           description: Filters the results by the exact subject distinguished name.
           required: false
           schema:
             type: string
-            example: 'CN=Example Device CA, O=Example Inc, C=US'
+            example: CN=Example Device CA, O=Example Inc, C=US
         - name: validityStatus
           in: query
           description: Filters certificates by their validity status.
@@ -173,21 +173,21 @@ paths:
                           -----BEGIN CERTIFICATE-----
                           MIID... (truncated) 
                           -----END CERTIFICATE-----
-                        subject: 'CN=Example Device CA One, O=Example Corp, C=US'
-                        issuer: 'CN=Example Intermediate CA, O=Example Corp, C=US'
-                        notBefore: '2025-01-01T00:00:00Z'
-                        notAfter: '2026-01-01T00:00:00Z'
-                        createdAt: '2025-05-10T10:30:00Z'
+                        subject: CN=Example Device CA One, O=Example Corp, C=US
+                        issuer: CN=Example Intermediate CA, O=Example Corp, C=US
+                        notBefore: 2025-01-01T00:00:00Z
+                        notAfter: 2026-01-01T00:00:00Z
+                        createdAt: 2025-05-10T10:30:00Z
                       - fingerprint: b2c3d4e5f6a78901234567890abcdef1b2c3d4e5f6a78901234567890abcdef1
                         pem: |
                           -----BEGIN CERTIFICATE-----
                           MIID... (truncated) 
                           -----END CERTIFICATE-----
-                        subject: 'CN=Example Device CA Two, O=Example Corp, C=US'
-                        issuer: 'CN=Example Intermediate CA, O=Example Corp, C=US'
-                        notBefore: '2025-02-15T00:00:00Z'
-                        notAfter: '2026-02-15T00:00:00Z'
-                        createdAt: '2025-06-20T12:00:00Z'
+                        subject: CN=Example Device CA Two, O=Example Corp, C=US
+                        issuer: CN=Example Intermediate CA, O=Example Corp, C=US
+                        notBefore: 2025-02-15T00:00:00Z
+                        notAfter: 2026-02-15T00:00:00Z
+                        createdAt: 2025-06-20T12:00:00Z
             application/x-pem-file:
               schema:
                 type: string
@@ -267,31 +267,31 @@ paths:
                     skipped: 0
                     malformed: 0
                     messages:
-                      - 'the certificate at position 1 with subject ''CN=Example Device CA One, O=Example Corp, C=US'' was imported successfully'
-                      - 'the certificate at position 2 with subject ''CN=Example Device CA Two, O=Example Corp, C=US'' was imported successfully'
+                      - the certificate at position 1 with subject 'CN=Example Device CA One, O=Example Corp, C=US' was imported successfully
+                      - the certificate at position 2 with subject 'CN=Example Device CA Two, O=Example Corp, C=US' was imported successfully
                     certs:
                       - fingerprint: c3d4e5f6a7b890123456789abcdef012c3d4e5f6a7b890123456789abcdef012
                         pem: |
                           -----BEGIN CERTIFICATE-----
                           MIID... (truncated) 
                           -----END CERTIFICATE-----
-                        subject: 'CN=Example Device CA One, O=Example Corp, C=US'
-                        issuer: 'CN=Example Intermediate CA, O=Example Corp, C=US'
-                        notBefore: '2025-10-01T00:00:00Z'
-                        notAfter: '2026-10-01T00:00:00Z'
-                        createdAt: '2025-10-27T14:00:00Z'
+                        subject: CN=Example Device CA One, O=Example Corp, C=US
+                        issuer: CN=Example Intermediate CA, O=Example Corp, C=US
+                        notBefore: 2025-10-01T00:00:00Z
+                        notAfter: 2026-10-01T00:00:00Z
+                        createdAt: 2025-10-27T14:00:00Z
                       - fingerprint: d4e5f6a7b8c901234567890abcdef123d4e5f6a7b8c901234567890abcdef123
                         pem: |
                           -----BEGIN CERTIFICATE-----
                           MIID... (truncated) 
                           -----END CERTIFICATE-----
-                        subject: 'CN=Example Device CA Two, O=Example Corp, C=US'
-                        issuer: 'CN=Example Intermediate CA, O=Example Corp, C=US'
-                        notBefore: '2025-10-01T00:00:00Z'
-                        notAfter: '2026-10-01T00:00:00Z'
-                        createdAt: '2025-10-27T14:00:00Z'
+                        subject: CN=Example Device CA Two, O=Example Corp, C=US
+                        issuer: CN=Example Intermediate CA, O=Example Corp, C=US
+                        notBefore: 2025-10-01T00:00:00Z
+                        notAfter: 2026-10-01T00:00:00Z
+                        createdAt: 2025-10-27T14:00:00Z
                 partialImport:
-                  summary: 'Some certificates skipped (duplicates, expired or malformed)'
+                  summary: Some certificates skipped (duplicates, expired or malformed)
                   value:
                     detected: 4
                     imported: 2
@@ -299,30 +299,30 @@ paths:
                     malformed: 1
                     messages:
                       - the certificate at position 1 is malformed
-                      - 'the certificate at position 2 with subject ''CN=Example Device CA One, O=Example Corp, C=US'' was imported successfully'
-                      - 'the certificate at position 3 with subject ''CN=Example Device CA Expired, O=Example Corp, C=US'' was skipped because it is expired'
-                      - 'the certificate at position 4 with subject ''CN=Example Device CA Two, O=Example Corp, C=US'' was imported successfully'
+                      - the certificate at position 2 with subject 'CN=Example Device CA One, O=Example Corp, C=US' was imported successfully
+                      - the certificate at position 3 with subject 'CN=Example Device CA Expired, O=Example Corp, C=US' was skipped because it is expired
+                      - the certificate at position 4 with subject 'CN=Example Device CA Two, O=Example Corp, C=US' was imported successfully
                     certs:
                       - fingerprint: c3d4e5f6a7b890123456789abcdef012c3d4e5f6a7b890123456789abcdef012
                         pem: |
                           -----BEGIN CERTIFICATE-----
                           MIID... (truncated) 
                           -----END CERTIFICATE-----
-                        subject: 'CN=Example Device CA One, O=Example Corp, C=US'
-                        issuer: 'CN=Example Intermediate CA, O=Example Corp, C=US'
-                        notBefore: '2025-10-01T00:00:00Z'
-                        notAfter: '2026-10-01T00:00:00Z'
-                        createdAt: '2025-10-27T14:00:00Z'
+                        subject: CN=Example Device CA One, O=Example Corp, C=US
+                        issuer: CN=Example Intermediate CA, O=Example Corp, C=US
+                        notBefore: 2025-10-01T00:00:00Z
+                        notAfter: 2026-10-01T00:00:00Z
+                        createdAt: 2025-10-27T14:00:00Z
                       - fingerprint: d4e5f6a7b8c901234567890abcdef123d4e5f6a7b8c901234567890abcdef123
                         pem: |
                           -----BEGIN CERTIFICATE-----
                           MIID... (truncated) 
                           -----END CERTIFICATE-----
-                        subject: 'CN=Example Device CA Two, O=Example Corp, C=US'
-                        issuer: 'CN=Example Intermediate CA, O=Example Corp, C=US'
-                        notBefore: '2025-10-01T00:00:00Z'
-                        notAfter: '2026-10-01T00:00:00Z'
-                        createdAt: '2025-10-27T14:00:00Z'
+                        subject: CN=Example Device CA Two, O=Example Corp, C=US
+                        issuer: CN=Example Intermediate CA, O=Example Corp, C=US
+                        notBefore: 2025-10-01T00:00:00Z
+                        notAfter: 2026-10-01T00:00:00Z
+                        createdAt: 2025-10-27T14:00:00Z
                 noneImported:
                   summary: All certificates already exist
                   value:
@@ -331,8 +331,8 @@ paths:
                     skipped: 2
                     malformed: 0
                     messages:
-                      - 'the certificate at position 1 with subject ''CN=Example Device CA One, O=Example Corp, C=US'' was skipped because it already exists'
-                      - 'the certificate at position 2 with subject ''CN=Example Device CA Two, O=Example Corp, C=US'' was skipped because it already exists'
+                      - the certificate at position 1 with subject 'CN=Example Device CA One, O=Example Corp, C=US' was skipped because it already exists
+                      - the certificate at position 2 with subject 'CN=Example Device CA Two, O=Example Corp, C=US' was skipped because it already exists
                     certs: []
         '400':
           $ref: '#/components/responses/BadRequest'
@@ -350,7 +350,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
       tags:
         - device-ca
-  '/v1/device-ca/{fingerprint}':
+  /v1/device-ca/{fingerprint}:
     get:
       operationId: GetTrustedDeviceCACertByFingerprint
       summary: Get a trusted device CA certificate by fingerprint
@@ -368,7 +368,7 @@ paths:
           schema:
             type: string
             example: a1b2c3d4e5f67890123456789abcdef0a1b2c3d4e5f67890123456789abcdef0
-            pattern: '^[a-f0-9]{64}$'
+            pattern: ^[a-f0-9]{64}$
       responses:
         '200':
           description: The requested trusted device CA certificate.
@@ -385,11 +385,11 @@ paths:
                       -----BEGIN CERTIFICATE-----
                       MIID... (truncated) 
                       -----END CERTIFICATE-----
-                    subject: 'CN=Example Device CA, O=Example Corp, C=US'
-                    issuer: 'CN=Example Intermediate CA, O=Example Corp, C=US'
-                    notBefore: '2025-01-01T00:00:00Z'
-                    notAfter: '2026-01-01T00:00:00Z'
-                    createdAt: '2025-05-10T10:30:00Z'
+                    subject: CN=Example Device CA, O=Example Corp, C=US
+                    issuer: CN=Example Intermediate CA, O=Example Corp, C=US
+                    notBefore: 2025-01-01T00:00:00Z
+                    notAfter: 2026-01-01T00:00:00Z
+                    createdAt: 2025-05-10T10:30:00Z
             application/x-pem-file:
               schema:
                 description: The certificate content in PEM format.
@@ -424,7 +424,7 @@ paths:
           schema:
             type: string
             example: a1b2c3d4e5f67890123456789abcdef0a1b2c3d4e5f67890123456789abcdef0
-            pattern: '^[a-f0-9]{64}$'
+            pattern: ^[a-f0-9]{64}$
       responses:
         '204':
           description: Trusted device CA certificate deleted successfully.
@@ -474,13 +474,13 @@ components:
           description: The SHA-256 fingerprint of the certificate (64 hexadecimal characters).
           type: string
           example: a1b2c3d4e5f67890123456789abcdef0a1b2c3d4e5f67890123456789abcdef0
-          pattern: '^[a-f0-9]{64}$'
+          pattern: ^[a-f0-9]{64}$
         pem:
           description: The full certificate content in PEM format.
           type: string
           format: pem
           maxLength: 32768
-          pattern: '^-----BEGIN CERTIFICATE-----\n[\s\S]+\n-----END CERTIFICATE-----\n?$'
+          pattern: ^-----BEGIN CERTIFICATE-----\n[\s\S]+\n-----END CERTIFICATE-----\n?$
         subject:
           description: The subject distinguished name of the certificate.
           type: string
@@ -556,12 +556,12 @@ components:
             type: string
           example:
             - the certificate at position 1 is malformed
-            - 'the certificate at position 2 with subject ''CN=Device CA 2,O=Example Inc'' was imported successfully'
-            - 'the certificate at position 3 with subject ''CN=Device CA 3,O=Example Inc'' was skipped because it is expired'
-            - 'the certificate at position 4 with subject ''CN=Device CA 4,O=Example Inc'' was skipped because it already exists'
-            - 'the certificate at position 5 with subject ''CN=Device CA 5,O=Example Inc'' was imported successfully'
+            - the certificate at position 2 with subject 'CN=Device CA 2,O=Example Inc' was imported successfully
+            - the certificate at position 3 with subject 'CN=Device CA 3,O=Example Inc' was skipped because it is expired
+            - the certificate at position 4 with subject 'CN=Device CA 4,O=Example Inc' was skipped because it already exists
+            - the certificate at position 5 with subject 'CN=Device CA 5,O=Example Inc' was imported successfully
         certs:
-          description: 'Array of certificates that were successfully imported (does not include malformed, expired or already existing certificates).'
+          description: Array of certificates that were successfully imported (does not include malformed, expired or already existing certificates).
           type: array
           items:
             $ref: '#/components/schemas/TrustedDeviceCACert'
@@ -609,7 +609,7 @@ components:
               value:
                 message: Invalid Request.
     Unauthorized:
-      description: 'Unauthorized - Authentication credentials missing, invalid, or expired.'
+      description: Unauthorized - Authentication credentials missing, invalid, or expired.
       content:
         application/json:
           schema:

--- a/build/package/rpm/go-fdo-server.spec
+++ b/build/package/rpm/go-fdo-server.spec
@@ -81,6 +81,9 @@ install -m 0644 -vp -D init/systemd/* %{buildroot}%{_unitdir}
 install -m 0755 -vd %{buildroot}%{_libexecdir}/%{name}
 install -m 0755 -vp scripts/cert-utils.sh %{buildroot}%{_libexecdir}/%{name}
 install -m 0755 -vp scripts/generate-go-fdo-server-certs.sh %{buildroot}%{_libexecdir}/%{name}
+# Man pages
+install -m 0755 -vd %{buildroot}%{_mandir}/man1
+install -m 0644 -vp docs/man/*.1 %{buildroot}%{_mandir}/man1
 
 %check
 %if %{with check}
@@ -97,6 +100,11 @@ install -m 0755 -vp scripts/generate-go-fdo-server-certs.sh %{buildroot}%{_libex
 %dir %{_libexecdir}/%{name}
 %{_libexecdir}/%{name}/cert-utils.sh
 %{_libexecdir}/%{name}/generate-go-fdo-server-certs.sh
+# Man pages
+%{_mandir}/man1/go-fdo-server.1*
+%{_mandir}/man1/go-fdo-server-manufacturing.1*
+%{_mandir}/man1/go-fdo-server-owner.1*
+%{_mandir}/man1/go-fdo-server-rendezvous.1*
 
 %pre
 %sysusers_create_compat %{SOURCE2}
@@ -105,11 +113,11 @@ install -m 0755 -vp scripts/generate-go-fdo-server-certs.sh %{buildroot}%{_libex
 Requires: go-fdo-server
 Requires: group(go-fdo-server)
 Requires: openssl
-Summary: A Go implementation of the FDO manufacturer server
+Summary: A Go implementation of the FDO Manufacturing server
 BuildArch: noarch
 %description manufacturer
-This package provides the manufacturer server component of the FDO stack.
-The manufacturer server is responsible for creating ownership vouchers and
+This package provides the Manufacturing server component of the FDO stack.
+The Manufacturing server is responsible for creating ownership vouchers and
 preparing devices for the on-boarding process during the manufacturing phase.
 
 %files manufacturer
@@ -135,11 +143,11 @@ preparing devices for the on-boarding process during the manufacturing phase.
 %package rendezvous
 Requires: go-fdo-server
 Requires: group(go-fdo-server)
-Summary: A Go implementation of the FDO rendezvous server
+Summary: A Go implementation of the FDO Rendezvous server
 BuildArch: noarch
 %description rendezvous
-This package provides the rendezvous server component of the FDO stack.
-The rendezvous server acts as a trusted intermediary, redirecting devices
+This package provides the Rendezvous server component of the FDO stack.
+The Rendezvous server acts as a trusted intermediary, redirecting devices
 to their designated owner's on-boarding service based on their ownership
 voucher.
 
@@ -166,10 +174,10 @@ voucher.
 %package owner
 Requires: go-fdo-server
 Requires: group(go-fdo-server)
-Summary: A Go implementation of the FDO owner server
+Summary: A Go implementation of the FDO Owner server
 BuildArch: noarch
 %description owner
-This package provides the owner server component of the FDO stack. The owner
+This package provides the Owner server component of the FDO stack. The Owner
 server is the final destination for a device during on-boarding. It verifies
 the device's authenticity, establishes ownership, and provisions it with the
 necessary credentials and configuration for operation.

--- a/cmd/manufacturing.go
+++ b/cmd/manufacturing.go
@@ -67,15 +67,15 @@ func (m *ManufacturingServerConfig) validate() error {
 		return err
 	}
 	// Validate device CA key exists
-	if err := validateCertFile(m.DeviceCA.KeyPath, "device CA key", "this key must be shared between manufacturer and owner servers"); err != nil {
+	if err := validateCertFile(m.DeviceCA.KeyPath, "device CA key", "this key must be shared between Manufacturing and Owner servers"); err != nil {
 		return err
 	}
 	// Validate device CA certificate exists
-	if err := validateCertFile(m.DeviceCA.CertPath, "device CA certificate", "this certificate must be shared between manufacturer and owner servers"); err != nil {
+	if err := validateCertFile(m.DeviceCA.CertPath, "device CA certificate", "this certificate must be shared between Manufacturing and Owner servers"); err != nil {
 		return err
 	}
 	// Validate owner certificate exists
-	if err := validateCertFile(m.Owner.OwnerCertificate, "owner certificate", "this certificate must come from the owner server deployment"); err != nil {
+	if err := validateCertFile(m.Owner.OwnerCertificate, "owner certificate", "this certificate must come from the Owner server deployment"); err != nil {
 		return err
 	}
 	return nil
@@ -83,8 +83,14 @@ func (m *ManufacturingServerConfig) validate() error {
 
 // manufacturingCmd represents the manufacturing command
 var manufacturingCmd = &cobra.Command{
-	Use:   "manufacturing http_address",
-	Short: "Serve an instance of the manufacturing server",
+	Use:   "manufacturing [ip_address:port]",
+	Short: "Run an FDO Manufacturing server",
+	Long: `Run an FDO Manufacturing server that handles device initialization (DI).
+
+The Manufacturing server runs the DI protocol to initialize devices and
+generate Ownership Vouchers.`,
+	Example: `  # Run a Manufacturing server on port 8038 using a configuration file:
+  go-fdo-server manufacturing 0.0.0.0:8038 --config /etc/go-fdo-server/manufacturing.yaml`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// Rebind only those keys needed by the manufacturing
 		// command. This is necessary because Viper cannot bind the
@@ -239,8 +245,8 @@ func serveManufacturing(config *ManufacturingServerConfig) error {
 		encodePublicKey,
 	)
 	if err = mfgHandler.InitDB(); err != nil {
-		slog.Error("failed to initialize manufacturing database", "err", err)
-		return fmt.Errorf("failed to initialize manufacturing database: %w", err)
+		slog.Error("failed to initialize Manufacturing database", "err", err)
+		return fmt.Errorf("failed to initialize Manufacturing database: %w", err)
 	}
 	slog.Info("Database initialized successfully", "type", config.DB.Type)
 	handler := mfgHandler.Handler()
@@ -288,6 +294,7 @@ func manufacturingCmdInit() {
 	manufacturingCmd.Flags().String("owner-cert", "", "Owner certificate path")
 	manufacturingCmd.Flags().String("device-ca-cert", "", "Device CA certificate path")
 	manufacturingCmd.Flags().String("device-ca-key", "", "Device CA private key path")
+	manufacturingCmd.Flags().BoolP("help", "h", false, "Help for Manufacturing server")
 }
 
 func init() {

--- a/cmd/owner.go
+++ b/cmd/owner.go
@@ -64,7 +64,7 @@ func (o *OwnerServerConfig) validate() error {
 		return err
 	}
 	// Validate device CA certificate exists
-	if err := validateCertFile(o.DeviceCA.CertPath, "device CA certificate", "this certificate must be shared with the manufacturer server"); err != nil {
+	if err := validateCertFile(o.DeviceCA.CertPath, "device CA certificate", "this certificate must be shared with the Manufacturing server"); err != nil {
 		return err
 	}
 
@@ -82,8 +82,14 @@ var (
 
 // ownerCmd represents the owner command
 var ownerCmd = &cobra.Command{
-	Use:   "owner http_address",
-	Short: "Serve an instance of the owner server",
+	Use:   "owner [ip_address:port]",
+	Short: "Run an FDO Owner server",
+	Long: `Run an FDO Owner server that handles device onboarding.
+
+The Owner server runs the TO2 protocol to onboard devices. It also runs the
+TO0 protocol against the Rendezvous server, registering itself as a device owner.`,
+	Example: `  # Run an Owner server on port 8043 using a configuration file:
+  go-fdo-server owner 0.0.0.0:8043 --config /etc/go-fdo-server/owner.yaml`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// Rebind only those keys needed by the owner command. This is
 		// necessary because Viper cannot bind the same key twice and
@@ -560,10 +566,11 @@ func ownerCmdInit() {
 
 	// Declare any CLI flags for overriding configuration file settings.
 	// These flags are bound to Viper in the ownerCmd PreRun handler.
-	ownerCmd.Flags().Bool("reuse-credentials", false, "Perform the Credential Reuse Protocol in TO2")
+	ownerCmd.Flags().Bool("reuse-credentials", false, "Perform the Credential Reuse Protocol during the TO2 protocol")
 	ownerCmd.Flags().String("device-ca-cert", "", "Device CA certificate path")
 	ownerCmd.Flags().String("owner-key", "", "Owner private key path")
-	ownerCmd.Flags().Bool("to0-insecure-tls", false, "Use insecure TLS (skip rendezvous certificate verification) for TO0")
+	ownerCmd.Flags().Bool("to0-insecure-tls", false, "Use insecure TLS (skip Rendezvous certificate verification) for the TO0 protocol")
+	ownerCmd.Flags().BoolP("help", "h", false, "Help for Owner server")
 }
 
 func init() {

--- a/cmd/rendezvous.go
+++ b/cmd/rendezvous.go
@@ -90,13 +90,13 @@ type RendezvousServerConfig struct {
 
 // validate checks that required configuration is present
 func (rv *RendezvousServerConfig) validate() error {
-	slog.Debug("Validating rendezvous server configuration")
+	slog.Debug("Validating Rendezvous server configuration")
 	if err := rv.HTTP.validate(); err != nil {
 		slog.Error("HTTP configuration validation failed", "err", err)
 		return err
 	}
 	if err := rv.Rendezvous.validate(); err != nil {
-		slog.Error("rendezvous configuration validation failed", "err", err)
+		slog.Error("Rendezvous configuration validation failed", "err", err)
 		return err
 	}
 	slog.Debug("Rendezvous server configuration validated successfully")
@@ -118,13 +118,13 @@ var rendezvousFlags = []rendezvousFlagConfig{
 		name:         "to0-min-wait",
 		viperKey:     "rendezvous.to0_min_wait",
 		defaultValue: defaultMinWaitSecs,
-		description:  "Minimum wait time in seconds for TO0 rendezvous entries (requests below this are rejected, default: 0 = no minimum)",
+		description:  "Minimum wait time the Rendezvous server will accept for an entry registered by the Owner server during TO0 protocol. If the Owner server requests a shorter wait time, it is rejected (default: 0 = no minimum)",
 	},
 	{
 		name:         "to0-max-wait",
 		viperKey:     "rendezvous.to0_max_wait",
 		defaultValue: defaultMaxWaitSecs,
-		description:  "Maximum wait time in seconds for TO0 rendezvous entries (requests above this are capped, default: %d seconds)",
+		description:  "Maximum wait time the Rendezvous server will keep an entry registered by the Owner server during TO0 protocol before it expires. If the Owner server requests a longer wait time, it is capped to this value (default: %d seconds)",
 	},
 	{
 		name:         "cleanup-interval",
@@ -148,8 +148,15 @@ var rendezvousFlags = []rendezvousFlagConfig{
 
 // rendezvousCmd represents the rendezvous command
 var rendezvousCmd = &cobra.Command{
-	Use:   "rendezvous http_address",
-	Short: "Serve an instance of the rendezvous server",
+	Use:   "rendezvous [ip_address:port]",
+	Short: "Run an FDO Rendezvous server",
+	Long: `Run an FDO Rendezvous server that mediates device onboarding.
+
+The Rendezvous server acts as an intermediary between devices and Owner servers.
+It accepts registration requests from Owner servers via the TO0 protocol and
+directs devices to their Owner server during the TO1 protocol.`,
+	Example: `  # Run a Rendezvous server on port 8041 using a configuration file:
+  go-fdo-server rendezvous 0.0.0.0:8041 --config /etc/go-fdo-server/rendezvous.yaml`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		slog.Debug("Binding rendezvous command flags")
 		// Rebind only those keys needed by the rendezvous command. This is
@@ -244,7 +251,7 @@ func (s *RendezvousServer) Start() error {
 }
 
 func serveRendezvous(config *RendezvousServerConfig) error {
-	slog.Info("Initializing rendezvous server")
+	slog.Info("Initializing Rendezvous server")
 
 	db, err := config.DB.getDB()
 	if err != nil {
@@ -258,8 +265,8 @@ func serveRendezvous(config *RendezvousServerConfig) error {
 
 	rendezvous := rendezvous.NewRendezvous(db, minWaitSecs, maxWaitSecs)
 	if err = rendezvous.InitDB(); err != nil {
-		slog.Error("failed to initialize rendezvous database", "err", err)
-		return fmt.Errorf("failed to initialize rendezvous database: %w", err)
+		slog.Error("failed to initialize Rendezvous database", "err", err)
+		return fmt.Errorf("failed to initialize Rendezvous database: %w", err)
 	}
 	slog.Info("Database initialized successfully", "type", config.DB.Type)
 
@@ -296,6 +303,8 @@ func serveRendezvous(config *RendezvousServerConfig) error {
 // Set up the rendezvous command line. Used by the unit tests to reset state between tests.
 func rendezvousCmdInit() {
 	rootCmd.AddCommand(rendezvousCmd)
+
+	rendezvousCmd.Flags().BoolP("help", "h", false, "Help for Rendezvous server")
 
 	// Register all flags and set viper defaults in a single loop
 	for _, flag := range rendezvousFlags {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -112,6 +112,7 @@ func Execute() {
 
 // Setup the root command line. Used by the unit tests to reset state between tests.
 func rootCmdInit() {
+	rootCmd.SetHelpCommand(&cobra.Command{Hidden: true})
 	rootCmd.PersistentFlags().String("config", "", "Pathname of the configuration file")
 	rootCmd.PersistentFlags().String("log-level", "info", "Set logging level (debug, info, warn, error)")
 	rootCmd.PersistentFlags().String("db-type", "sqlite", "Database type (sqlite or postgres)")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,13 +34,14 @@ var rootCmd = &cobra.Command{
 	CompletionOptions: cobra.CompletionOptions{
 		DisableDefaultCmd: true,
 	},
-	Use:   "go-fdo-server",
-	Short: "Server implementation of FIDO Device Onboard specification in Go",
-	Long: `Server implementation of the three main FDO servers. It can act
-	as a Manufacturer, Owner and Rendezvous.
+	Use:   "go-fdo-server {manufacturing|rendezvous|owner}",
+	Short: "Run a FIDO Device Onboard (FDO) server",
+	Long: `Run an FDO Manufacturing, Rendezvous, or Owner server.
 
-	The server also provides APIs to interact with the various servers implementations.
-`,
+Use one of the subcommands to run a Manufacturing, Rendezvous, or Owner
+server instance. Each subcommand accepts an ip_address:port argument specifying the listen address.`,
+	Example: `  # Run a Manufacturing server on port 8038 using a configuration file:
+  go-fdo-server manufacturing 0.0.0.0:8038 --config /etc/go-fdo-server/manufacturing.yaml`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		// bootstrap debug logging early to include configuration loading
 		level, _ := cmd.Flags().GetString("log-level")
@@ -87,11 +88,11 @@ var rootCmd = &cobra.Command{
 			logLevel.Set(slog.LevelError)
 		}
 
-		// Parse HTTP address from positional argument if provided
+		// Parse ip_address:port from positional argument if provided
 		if len(args) > 0 {
 			ip, port, err := parseHTTPAddress(args[0])
 			if err != nil {
-				return fmt.Errorf("invalid http_address: %w", err)
+				return fmt.Errorf("invalid ip_address:port: %w", err)
 			}
 			viper.Set("http.ip", ip)
 			viper.Set("http.port", port)
@@ -100,6 +101,9 @@ var rootCmd = &cobra.Command{
 		return nil
 	},
 }
+
+// Root returns the root cobra command for use by documentation generators.
+func Root() *cobra.Command { return rootCmd }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.

--- a/docs/man/go-fdo-server-manufacturing.1
+++ b/docs/man/go-fdo-server-manufacturing.1
@@ -1,0 +1,74 @@
+.nh
+.TH "GO-FDO-SERVER-MANUFACTURING" "1" "Apr 2026" "go-fdo-server" "Go FDO Server"
+
+.SH NAME
+go-fdo-server-manufacturing - Run an FDO Manufacturing server
+
+
+.SH SYNOPSIS
+\fBgo-fdo-server manufacturing [ip_address:port] [flags]\fP
+
+
+.SH DESCRIPTION
+Run an FDO Manufacturing server that handles device initialization (DI).
+
+.PP
+The Manufacturing server runs the DI protocol to initialize devices and
+generate Ownership Vouchers.
+
+
+.SH OPTIONS
+\fB--device-ca-cert\fP=""
+	Device CA certificate path
+
+.PP
+\fB--device-ca-key\fP=""
+	Device CA private key path
+
+.PP
+\fB-h\fP, \fB--help\fP[=false]
+	Help for Manufacturing server
+
+.PP
+\fB--manufacturing-key\fP=""
+	Manufacturing private key path
+
+.PP
+\fB--owner-cert\fP=""
+	Owner certificate path
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+\fB--config\fP=""
+	Pathname of the configuration file
+
+.PP
+\fB--db-dsn\fP=""
+	Database DSN (connection string)
+
+.PP
+\fB--db-type\fP="sqlite"
+	Database type (sqlite or postgres)
+
+.PP
+\fB--http-cert\fP=""
+	Path to server certificate
+
+.PP
+\fB--http-key\fP=""
+	Path to server private key
+
+.PP
+\fB--log-level\fP="info"
+	Set logging level (debug, info, warn, error)
+
+
+.SH EXAMPLE
+.EX
+  # Run a Manufacturing server on port 8038 using a configuration file:
+  go-fdo-server manufacturing 0.0.0.0:8038 --config /etc/go-fdo-server/manufacturing.yaml
+.EE
+
+
+.SH SEE ALSO
+\fBgo-fdo-server(1)\fP

--- a/docs/man/go-fdo-server-owner.1
+++ b/docs/man/go-fdo-server-owner.1
@@ -1,0 +1,74 @@
+.nh
+.TH "GO-FDO-SERVER-OWNER" "1" "Apr 2026" "go-fdo-server" "Go FDO Server"
+
+.SH NAME
+go-fdo-server-owner - Run an FDO Owner server
+
+
+.SH SYNOPSIS
+\fBgo-fdo-server owner [ip_address:port] [flags]\fP
+
+
+.SH DESCRIPTION
+Run an FDO Owner server that handles device onboarding.
+
+.PP
+The Owner server runs the TO2 protocol to onboard devices. It also runs the
+TO0 protocol against the Rendezvous server, registering itself as a device owner.
+
+
+.SH OPTIONS
+\fB--device-ca-cert\fP=""
+	Device CA certificate path
+
+.PP
+\fB-h\fP, \fB--help\fP[=false]
+	Help for Owner server
+
+.PP
+\fB--owner-key\fP=""
+	Owner private key path
+
+.PP
+\fB--reuse-credentials\fP[=false]
+	Perform the Credential Reuse Protocol during the TO2 protocol
+
+.PP
+\fB--to0-insecure-tls\fP[=false]
+	Use insecure TLS (skip Rendezvous certificate verification) for the TO0 protocol
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+\fB--config\fP=""
+	Pathname of the configuration file
+
+.PP
+\fB--db-dsn\fP=""
+	Database DSN (connection string)
+
+.PP
+\fB--db-type\fP="sqlite"
+	Database type (sqlite or postgres)
+
+.PP
+\fB--http-cert\fP=""
+	Path to server certificate
+
+.PP
+\fB--http-key\fP=""
+	Path to server private key
+
+.PP
+\fB--log-level\fP="info"
+	Set logging level (debug, info, warn, error)
+
+
+.SH EXAMPLE
+.EX
+  # Run an Owner server on port 8043 using a configuration file:
+  go-fdo-server owner 0.0.0.0:8043 --config /etc/go-fdo-server/owner.yaml
+.EE
+
+
+.SH SEE ALSO
+\fBgo-fdo-server(1)\fP

--- a/docs/man/go-fdo-server-rendezvous.1
+++ b/docs/man/go-fdo-server-rendezvous.1
@@ -1,0 +1,79 @@
+.nh
+.TH "GO-FDO-SERVER-RENDEZVOUS" "1" "Apr 2026" "go-fdo-server" "Go FDO Server"
+
+.SH NAME
+go-fdo-server-rendezvous - Run an FDO Rendezvous server
+
+
+.SH SYNOPSIS
+\fBgo-fdo-server rendezvous [ip_address:port] [flags]\fP
+
+
+.SH DESCRIPTION
+Run an FDO Rendezvous server that mediates device onboarding.
+
+.PP
+The Rendezvous server acts as an intermediary between devices and Owner servers.
+It accepts registration requests from Owner servers via the TO0 protocol and
+directs devices to their Owner server during the TO1 protocol.
+
+
+.SH OPTIONS
+\fB--cleanup-interval\fP=3600
+	Interval in seconds for automatic cleanup of expired rendezvous blobs and sessions (set to 0 to disable, default: 3600 seconds)
+
+.PP
+\fB-h\fP, \fB--help\fP[=false]
+	Help for Rendezvous server
+
+.PP
+\fB--initial-cleanup-delay\fP=300
+	Delay in seconds before first cleanup after startup (default: 300 seconds)
+
+.PP
+\fB--session-timeout\fP=3600
+	Maximum age in seconds for sessions before cleanup (default: 3600 seconds)
+
+.PP
+\fB--to0-max-wait\fP=86400
+	Maximum wait time the Rendezvous server will keep an entry registered by the Owner server during TO0 protocol before it expires. If the Owner server requests a longer wait time, it is capped to this value (default: 86400 seconds)
+
+.PP
+\fB--to0-min-wait\fP=0
+	Minimum wait time the Rendezvous server will accept for an entry registered by the Owner server during TO0 protocol. If the Owner server requests a shorter wait time, it is rejected (default: 0 = no minimum)
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+\fB--config\fP=""
+	Pathname of the configuration file
+
+.PP
+\fB--db-dsn\fP=""
+	Database DSN (connection string)
+
+.PP
+\fB--db-type\fP="sqlite"
+	Database type (sqlite or postgres)
+
+.PP
+\fB--http-cert\fP=""
+	Path to server certificate
+
+.PP
+\fB--http-key\fP=""
+	Path to server private key
+
+.PP
+\fB--log-level\fP="info"
+	Set logging level (debug, info, warn, error)
+
+
+.SH EXAMPLE
+.EX
+  # Run a Rendezvous server on port 8041 using a configuration file:
+  go-fdo-server rendezvous 0.0.0.0:8041 --config /etc/go-fdo-server/rendezvous.yaml
+.EE
+
+
+.SH SEE ALSO
+\fBgo-fdo-server(1)\fP

--- a/docs/man/go-fdo-server.1
+++ b/docs/man/go-fdo-server.1
@@ -1,0 +1,57 @@
+.nh
+.TH "GO-FDO-SERVER" "1" "Apr 2026" "go-fdo-server" "Go FDO Server"
+
+.SH NAME
+go-fdo-server - Run a FIDO Device Onboard (FDO) server
+
+
+.SH SYNOPSIS
+\fBgo-fdo-server {manufacturing|rendezvous|owner} [flags]\fP
+
+
+.SH DESCRIPTION
+Run an FDO Manufacturing, Rendezvous, or Owner server.
+
+.PP
+Use one of the subcommands to run a Manufacturing, Rendezvous, or Owner
+server instance. Each subcommand accepts an ip_address:port argument specifying the listen address.
+
+
+.SH OPTIONS
+\fB--config\fP=""
+	Pathname of the configuration file
+
+.PP
+\fB--db-dsn\fP=""
+	Database DSN (connection string)
+
+.PP
+\fB--db-type\fP="sqlite"
+	Database type (sqlite or postgres)
+
+.PP
+\fB-h\fP, \fB--help\fP[=false]
+	help for go-fdo-server
+
+.PP
+\fB--http-cert\fP=""
+	Path to server certificate
+
+.PP
+\fB--http-key\fP=""
+	Path to server private key
+
+.PP
+\fB--log-level\fP="info"
+	Set logging level (debug, info, warn, error)
+
+
+.SH EXAMPLE
+.EX
+  # Run a Manufacturing server on port 8038 using a configuration file:
+  go-fdo-server manufacturing 0.0.0.0:8038 --config /etc/go-fdo-server/manufacturing.yaml
+.EE
+
+
+.SH SEE ALSO
+\fBgo-fdo-server-manufacturing(1)\fP, \fBgo-fdo-server-owner(1)\fP, \fBgo-fdo-server-rendezvous(1)\fP

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 
 require (
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
 	github.com/dprotaso/go-yit v0.0.0-20220510233725-9ba8df137936 // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
 	github.com/getkin/kin-openapi v0.133.0 // indirect
@@ -43,6 +44,7 @@ require (
 	github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sagikazarmark/locafero v0.7.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/speakeasy-api/jsonpath v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,7 @@ github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvF
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
+github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -133,6 +134,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.7.0 h1:5MqpDsTGNDhY8sGp0Aowyf0qKsPrhewaLSsFaodPcyo=
 github.com/sagikazarmark/locafero v0.7.0/go.mod h1:2za3Cg5rMaTMoG/2Ulr9AwtFaIppKXTRYnozin4aB5k=

--- a/internal/tools/docgen/main.go
+++ b/internal/tools/docgen/main.go
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: (C) 2024 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/fido-device-onboard/go-fdo-server/cmd"
+	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
+)
+
+func main() {
+	format := flag.String("format", "man", "Output format: man or markdown")
+	out := flag.String("out", "", "Output directory (default: docs/man for man, docs/cli for markdown)")
+	flag.Parse()
+
+	if err := run(*format, *out); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(format, outDir string) error {
+	root := cmd.Root()
+	disableAutoGenTag(root)
+
+	defaults := map[string]string{"man": "docs/man", "markdown": "docs/cli"}
+	defaultDir, ok := defaults[format]
+	if !ok {
+		return fmt.Errorf("unknown format %q: must be \"man\" or \"markdown\"", format)
+	}
+
+	if outDir == "" {
+		outDir = defaultDir
+	}
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create output directory: %w", err)
+	}
+
+	switch format {
+	case "man":
+		header := &doc.GenManHeader{
+			Section: "1",
+			Source:  "go-fdo-server",
+			Manual:  "Go FDO Server",
+		}
+		if err := doc.GenManTree(root, header, outDir); err != nil {
+			return fmt.Errorf("failed to generate man pages: %w", err)
+		}
+	case "markdown":
+		if err := doc.GenMarkdownTree(root, outDir); err != nil {
+			return fmt.Errorf("failed to generate markdown docs: %w", err)
+		}
+	default:
+		return fmt.Errorf("unsupported format %q\n", format)
+	}
+
+	fmt.Printf("Generated %s documentation in %s\n", format, outDir)
+	return nil
+}
+
+func disableAutoGenTag(cmd *cobra.Command) {
+	cmd.DisableAutoGenTag = true
+	for _, child := range cmd.Commands() {
+		disableAutoGenTag(child)
+	}
+}

--- a/internal/tools/docgen/main_test.go
+++ b/internal/tools/docgen/main_test.go
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: (C) 2024 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRunManFormat(t *testing.T) {
+	outDir := t.TempDir()
+	if err := run("man", outDir); err != nil {
+		t.Fatalf("run(\"man\") failed: %v", err)
+	}
+
+	expected := []string{
+		"go-fdo-server.1",
+		"go-fdo-server-manufacturing.1",
+		"go-fdo-server-owner.1",
+		"go-fdo-server-rendezvous.1",
+	}
+	for _, name := range expected {
+		path := filepath.Join(outDir, name)
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Errorf("expected man page %s not found: %v", name, err)
+			continue
+		}
+		if info.Size() == 0 {
+			t.Errorf("man page %s is empty", name)
+		}
+	}
+}
+
+func TestRunMarkdownFormat(t *testing.T) {
+	outDir := t.TempDir()
+	if err := run("markdown", outDir); err != nil {
+		t.Fatalf("run(\"markdown\") failed: %v", err)
+	}
+
+	expected := []string{
+		"go-fdo-server.md",
+		"go-fdo-server_manufacturing.md",
+		"go-fdo-server_owner.md",
+		"go-fdo-server_rendezvous.md",
+	}
+	for _, name := range expected {
+		path := filepath.Join(outDir, name)
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Errorf("expected markdown file %s not found: %v", name, err)
+			continue
+		}
+		if info.Size() == 0 {
+			t.Errorf("markdown file %s is empty", name)
+		}
+	}
+}
+
+func TestRunCreatesOutputDir(t *testing.T) {
+	outDir := filepath.Join(t.TempDir(), "nested", "output")
+	if err := run("man", outDir); err != nil {
+		t.Fatalf("run() failed to create nested output dir: %v", err)
+	}
+	if _, err := os.Stat(outDir); err != nil {
+		t.Fatalf("output directory was not created: %v", err)
+	}
+}
+
+func TestRunUnknownFormat(t *testing.T) {
+	outDir := t.TempDir()
+	err := run("bogus", outDir)
+	if err == nil {
+		t.Fatal("expected error for unknown format, got nil")
+	}
+}
+
+func TestRunInvalidOutputDir(t *testing.T) {
+	err := run("man", "/dev/null/invalid")
+	if err == nil {
+		t.Fatal("expected error for invalid output dir, got nil")
+	}
+}


### PR DESCRIPTION
Add an internal docgen tool (internal/tools/docgen) that uses cobra's doc package to generate man pages and markdown documentation from the CLI command definitions. Add a "man" Makefile target and include the generated man pages in RPM packaging.

Improve Short, Long, and Example fields for all cobra commands to provide clearer help output and better generated documentation.

Closes: #204