### PR TITLE
fix: clean up upload directories and session state on TO2 failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,64 @@ jobs:
           source test/ci/test-fsim-upload.sh
           cleanup
 
+  test-upload-cleanup:
+    name: Test upload directory cleanup on TO2 failure
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install golang
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Test upload directory cleanup
+        run: |
+          source test/ci/test-upload-cleanup.sh
+          run_test
+
+      - name: Get Manufacturer, Rendezvous and Owner server logs
+        if: always()
+        run: |
+          source test/ci/test-upload-cleanup.sh
+          get_logs
+
+      - name: Cleanup the environment
+        if: always()
+        run: |
+          source test/ci/test-upload-cleanup.sh
+          cleanup
+
+  test-upload-cleanup-missing-file:
+    name: Test upload directory cleanup on missing file
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install golang
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Test upload directory cleanup (missing file)
+        run: |
+          source test/ci/test-upload-cleanup-missing-file.sh
+          run_test
+
+      - name: Get Manufacturer, Rendezvous and Owner server logs
+        if: always()
+        run: |
+          source test/ci/test-upload-cleanup-missing-file.sh
+          get_logs
+
+      - name: Cleanup the environment
+        if: always()
+        run: |
+          source test/ci/test-upload-cleanup-missing-file.sh
+          cleanup
+
   test-fsim-download:
     name: Test FSIM fdo.download
     runs-on: ubuntu-latest

--- a/cmd/owner.go
+++ b/cmd/owner.go
@@ -340,10 +340,12 @@ type moduleStateMachines struct {
 }
 
 type moduleStateMachineState struct {
-	Name string
-	Impl serviceinfo.OwnerModule
-	Next func() (string, serviceinfo.OwnerModule, bool)
-	Stop func()
+	Name       string
+	Impl       serviceinfo.OwnerModule
+	Next       func() (string, serviceinfo.OwnerModule, bool)
+	Stop       func()
+	Completed  bool     // true when all modules have been yielded
+	UploadDirs []string // GUID-based upload directories created during this session
 }
 
 func (s moduleStateMachines) Module(ctx context.Context) (string, serviceinfo.OwnerModule, error) {
@@ -370,16 +372,18 @@ func (s moduleStateMachines) NextModule(ctx context.Context) (bool, error) {
 		if err != nil {
 			return false, fmt.Errorf("error getting devmod: %w", err)
 		}
-		next, stop := iter.Pull2(ownerModules(ctx, s.config, modules, s.DB))
-		module = &moduleStateMachineState{
-			Next: next,
-			Stop: stop,
-		}
+		module = &moduleStateMachineState{}
+		next, stop := iter.Pull2(ownerModules(ctx, s.config, modules, s.DB, &module.UploadDirs))
+		module.Next = next
+		module.Stop = stop
 		s.states[token] = module
 	}
 
 	var valid bool
 	module.Name, module.Impl, valid = module.Next()
+	if !valid {
+		module.Completed = true
+	}
 	return valid, nil
 }
 
@@ -393,10 +397,42 @@ func (s moduleStateMachines) CleanupModules(ctx context.Context) {
 		return
 	}
 	module.Stop()
+	s.cleanupUploadDirs(module)
 	delete(s.states, token)
+
+	// Sweep orphaned states from previous sessions that were invalidated
+	// by the transport layer (e.g. client disconnect) without a
+	// CleanupModules call.
+	s.sweepStaleStates()
 }
 
-func ownerModules(ctx context.Context, config *ServiceInfoConfig, modules []string, dbState *db.State) iter.Seq2[string, serviceinfo.OwnerModule] { //nolint:gocyclo
+// cleanupUploadDirs removes GUID-based upload directories if modules
+// did not complete naturally (i.e. TO2 failed).
+func (s moduleStateMachines) cleanupUploadDirs(module *moduleStateMachineState) {
+	if module.Completed {
+		return
+	}
+	for _, dir := range module.UploadDirs {
+		slog.Info("fdo.upload: cleaning up upload directory after TO2 failure", "dir", dir)
+		if err := os.RemoveAll(dir); err != nil {
+			slog.Error("fdo.upload: failed to clean up upload directory", "dir", dir, "err", err)
+		}
+	}
+}
+
+// sweepStaleStates iterates the states map and cleans up entries whose
+// sessions no longer exist in the database.
+func (s moduleStateMachines) sweepStaleStates() {
+	for token, module := range s.states {
+		if !s.DB.SessionExists(token) {
+			module.Stop()
+			s.cleanupUploadDirs(module)
+			delete(s.states, token)
+		}
+	}
+}
+
+func ownerModules(ctx context.Context, config *ServiceInfoConfig, modules []string, dbState *db.State, uploadDirs *[]string) iter.Seq2[string, serviceinfo.OwnerModule] { //nolint:gocyclo
 	return func(yield func(string, serviceinfo.OwnerModule) bool) {
 		if config == nil || len(config.Fsims) == 0 {
 			return
@@ -455,6 +491,11 @@ func ownerModules(ctx context.Context, config *ServiceInfoConfig, modules []stri
 						return
 					}
 					uploadDir = filepath.Join(uploadDir, hex.EncodeToString(replacementGUID[:]))
+
+					// Track the top-level GUID directory for cleanup on failure
+					if !slices.Contains(*uploadDirs, uploadDir) {
+						*uploadDirs = append(*uploadDirs, uploadDir)
+					}
 
 					// note: file.Dst has been validated as a relative path.
 					if file.Dst != "" {

--- a/cmd/owner.go
+++ b/cmd/owner.go
@@ -242,7 +242,7 @@ func serveOwner(config *OwnerServerConfig) error {
 		RvInfo: func(_ context.Context, voucher fdo.Voucher) ([][]protocol.RvInstruction, error) {
 			return voucher.Header.Val.RvInfo, nil
 		},
-		Modules:         moduleStateMachines{DB: state.DB, config: &config.Owner.ServiceInfo, states: make(map[string]*moduleStateMachineState)},
+		Modules:         &moduleStateMachines{DB: state.DB, config: &config.Owner.ServiceInfo, states: make(map[string]*moduleStateMachineState)},
 		ReuseCredential: func(context.Context, fdo.Voucher) (bool, error) { return config.Owner.ReuseCred, nil },
 		VerifyVoucher: func(_ context.Context, voucher fdo.Voucher) error {
 			return handlers.VerifyVoucher(&voucher, []crypto.PublicKey{state.ownerKey.Public()})
@@ -332,11 +332,14 @@ func (state *OwnerServerState) OwnerKey(ctx context.Context, keyType protocol.Ke
 	return state.ownerKey, state.chain, nil
 }
 
+const sweepInterval = 1 * time.Minute
+
 type moduleStateMachines struct {
 	DB     *db.State
 	config *ServiceInfoConfig
 	// current module state machine state for all sessions (indexed by token)
-	states map[string]*moduleStateMachineState
+	states    map[string]*moduleStateMachineState
+	lastSweep time.Time
 }
 
 type moduleStateMachineState struct {
@@ -348,7 +351,7 @@ type moduleStateMachineState struct {
 	UploadDirs []string // GUID-based upload directories created during this session
 }
 
-func (s moduleStateMachines) Module(ctx context.Context) (string, serviceinfo.OwnerModule, error) {
+func (s *moduleStateMachines) Module(ctx context.Context) (string, serviceinfo.OwnerModule, error) {
 	token, ok := s.DB.TokenFromContext(ctx)
 	if !ok {
 		return "", nil, fmt.Errorf("invalid context: no token")
@@ -360,13 +363,20 @@ func (s moduleStateMachines) Module(ctx context.Context) (string, serviceinfo.Ow
 	return module.Name, module.Impl, nil
 }
 
-func (s moduleStateMachines) NextModule(ctx context.Context) (bool, error) {
+func (s *moduleStateMachines) NextModule(ctx context.Context) (bool, error) {
 	token, ok := s.DB.TokenFromContext(ctx)
 	if !ok {
 		return false, fmt.Errorf("invalid context: no token")
 	}
 	module, ok := s.states[token]
 	if !ok {
+		// Sweep orphaned states from previous sessions before creating a
+		// new one. Throttled to avoid excessive DB queries under load.
+		if time.Since(s.lastSweep) >= sweepInterval {
+			s.sweepStaleStates()
+			s.lastSweep = time.Now()
+		}
+
 		// Create a new module state machine
 		_, modules, _, err := s.DB.Devmod(ctx)
 		if err != nil {
@@ -387,7 +397,7 @@ func (s moduleStateMachines) NextModule(ctx context.Context) (bool, error) {
 	return valid, nil
 }
 
-func (s moduleStateMachines) CleanupModules(ctx context.Context) {
+func (s *moduleStateMachines) CleanupModules(ctx context.Context) {
 	token, ok := s.DB.TokenFromContext(ctx)
 	if !ok {
 		return
@@ -399,16 +409,11 @@ func (s moduleStateMachines) CleanupModules(ctx context.Context) {
 	module.Stop()
 	s.cleanupUploadDirs(module)
 	delete(s.states, token)
-
-	// Sweep orphaned states from previous sessions that were invalidated
-	// by the transport layer (e.g. client disconnect) without a
-	// CleanupModules call.
-	s.sweepStaleStates()
 }
 
 // cleanupUploadDirs removes GUID-based upload directories if modules
 // did not complete naturally (i.e. TO2 failed).
-func (s moduleStateMachines) cleanupUploadDirs(module *moduleStateMachineState) {
+func (s *moduleStateMachines) cleanupUploadDirs(module *moduleStateMachineState) {
 	if module.Completed {
 		return
 	}
@@ -422,7 +427,7 @@ func (s moduleStateMachines) cleanupUploadDirs(module *moduleStateMachineState) 
 
 // sweepStaleStates iterates the states map and cleans up entries whose
 // sessions no longer exist in the database.
-func (s moduleStateMachines) sweepStaleStates() {
+func (s *moduleStateMachines) sweepStaleStates() {
 	for token, module := range s.states {
 		if !s.DB.SessionExists(token) {
 			module.Stop()

--- a/cmd/owner.go
+++ b/cmd/owner.go
@@ -21,6 +21,7 @@ import (
 	"path"
 	"path/filepath"
 	"slices"
+	"sync"
 	"syscall"
 	"time"
 
@@ -335,6 +336,7 @@ func (state *OwnerServerState) OwnerKey(ctx context.Context, keyType protocol.Ke
 const sweepInterval = 1 * time.Minute
 
 type moduleStateMachines struct {
+	mu     sync.Mutex
 	DB     *db.State
 	config *ServiceInfoConfig
 	// current module state machine state for all sessions (indexed by token)
@@ -352,6 +354,9 @@ type moduleStateMachineState struct {
 }
 
 func (s *moduleStateMachines) Module(ctx context.Context) (string, serviceinfo.OwnerModule, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	token, ok := s.DB.TokenFromContext(ctx)
 	if !ok {
 		return "", nil, fmt.Errorf("invalid context: no token")
@@ -364,6 +369,9 @@ func (s *moduleStateMachines) Module(ctx context.Context) (string, serviceinfo.O
 }
 
 func (s *moduleStateMachines) NextModule(ctx context.Context) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	token, ok := s.DB.TokenFromContext(ctx)
 	if !ok {
 		return false, fmt.Errorf("invalid context: no token")
@@ -398,6 +406,9 @@ func (s *moduleStateMachines) NextModule(ctx context.Context) (bool, error) {
 }
 
 func (s *moduleStateMachines) CleanupModules(ctx context.Context) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	token, ok := s.DB.TokenFromContext(ctx)
 	if !ok {
 		return
@@ -411,8 +422,9 @@ func (s *moduleStateMachines) CleanupModules(ctx context.Context) {
 	delete(s.states, token)
 }
 
-// cleanupUploadDirs removes GUID-based upload directories if modules
-// did not complete naturally (i.e. TO2 failed).
+// cleanupUploadDirs performs best-effort removal of GUID-based upload
+// directories if modules did not complete naturally (i.e. TO2 failed).
+// If removal fails, the directory is left in place and the error is logged.
 func (s *moduleStateMachines) cleanupUploadDirs(module *moduleStateMachineState) {
 	if module.Completed {
 		return

--- a/cmd/owner_cleanup_test.go
+++ b/cmd/owner_cleanup_test.go
@@ -92,22 +92,14 @@ func TestCleanupModules_NoStateNoPanic(t *testing.T) {
 	sm.CleanupModules(ctx)
 }
 
-func TestCleanupModules_SweepsOrphanedStates(t *testing.T) {
+func TestSweepStaleStates_CleansOrphanedSessions(t *testing.T) {
 	// Set up a real in-memory DB so SessionExists works
 	dbState, err := db.InitDb("sqlite", "file::memory:?cache=shared")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// Create a session for the "active" token (the one being cleaned up normally)
-	activeToken, err := dbState.NewToken(context.Background(), protocol.TO2Protocol)
-	if err != nil {
-		t.Fatal(err)
-	}
-	activeCtx := dbState.TokenContext(context.Background(), activeToken)
-
-	// Create a session for the "orphan" token, then invalidate it
-	// (simulates transport layer invalidating on client disconnect)
+	// Create a session then invalidate it to simulate client disconnect
 	orphanToken, err := dbState.NewToken(context.Background(), protocol.TO2Protocol)
 	if err != nil {
 		t.Fatal(err)
@@ -127,10 +119,6 @@ func TestCleanupModules_SweepsOrphanedStates(t *testing.T) {
 	sm := moduleStateMachines{
 		DB: dbState,
 		states: map[string]*moduleStateMachineState{
-			activeToken: {
-				Completed: true,
-				Stop:      func() {},
-			},
 			orphanToken: {
 				Completed:  false,
 				UploadDirs: []string{orphanDir},
@@ -139,15 +127,14 @@ func TestCleanupModules_SweepsOrphanedStates(t *testing.T) {
 		},
 	}
 
-	// CleanupModules for the active session should also sweep the orphan
-	sm.CleanupModules(activeCtx)
+	sm.sweepStaleStates()
 
 	// Orphan's upload dir should be removed
 	if _, err := os.Stat(orphanDir); !os.IsNotExist(err) {
 		t.Error("expected orphaned upload directory to be removed by sweep")
 	}
 
-	// Both entries should be gone from the states map
+	// Orphan entry should be gone from the states map
 	if len(sm.states) != 0 {
 		t.Errorf("expected states map to be empty, got %d entries", len(sm.states))
 	}

--- a/cmd/owner_cleanup_test.go
+++ b/cmd/owner_cleanup_test.go
@@ -1,0 +1,154 @@
+// SPDX-FileCopyrightText: (C) 2024 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
+
+package cmd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/fido-device-onboard/go-fdo/protocol"
+
+	"github.com/fido-device-onboard/go-fdo-server/internal/db"
+)
+
+func TestCleanupModules_RemovesDirsOnFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+	dir1 := filepath.Join(tmpDir, "guid1")
+	dir2 := filepath.Join(tmpDir, "guid2")
+	if err := os.MkdirAll(dir1, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dir2, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	dbState := &db.State{}
+	token := "test-token"
+	ctx := dbState.TokenContext(context.Background(), token)
+
+	sm := moduleStateMachines{
+		DB: dbState,
+		states: map[string]*moduleStateMachineState{
+			token: {
+				Completed:  false,
+				UploadDirs: []string{dir1, dir2},
+				Stop:       func() {},
+			},
+		},
+	}
+
+	sm.CleanupModules(ctx)
+
+	for _, dir := range []string{dir1, dir2} {
+		if _, err := os.Stat(dir); !os.IsNotExist(err) {
+			t.Errorf("expected directory %s to be removed, but it still exists", dir)
+		}
+	}
+}
+
+func TestCleanupModules_KeepsDirsOnSuccess(t *testing.T) {
+	tmpDir := t.TempDir()
+	dir1 := filepath.Join(tmpDir, "guid1")
+	if err := os.MkdirAll(dir1, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	dbState := &db.State{}
+	token := "test-token"
+	ctx := dbState.TokenContext(context.Background(), token)
+
+	sm := moduleStateMachines{
+		DB: dbState,
+		states: map[string]*moduleStateMachineState{
+			token: {
+				Completed:  true,
+				UploadDirs: []string{dir1},
+				Stop:       func() {},
+			},
+		},
+	}
+
+	sm.CleanupModules(ctx)
+
+	if _, err := os.Stat(dir1); os.IsNotExist(err) {
+		t.Error("expected directory to be kept on successful completion, but it was removed")
+	}
+}
+
+func TestCleanupModules_NoStateNoPanic(t *testing.T) {
+	dbState := &db.State{}
+	token := "unknown-token"
+	ctx := dbState.TokenContext(context.Background(), token)
+
+	sm := moduleStateMachines{
+		DB:     dbState,
+		states: map[string]*moduleStateMachineState{},
+	}
+
+	// Should return silently without panicking
+	sm.CleanupModules(ctx)
+}
+
+func TestCleanupModules_SweepsOrphanedStates(t *testing.T) {
+	// Set up a real in-memory DB so SessionExists works
+	dbState, err := db.InitDb("sqlite", "file::memory:?cache=shared")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a session for the "active" token (the one being cleaned up normally)
+	activeToken, err := dbState.NewToken(context.Background(), protocol.TO2Protocol)
+	if err != nil {
+		t.Fatal(err)
+	}
+	activeCtx := dbState.TokenContext(context.Background(), activeToken)
+
+	// Create a session for the "orphan" token, then invalidate it
+	// (simulates transport layer invalidating on client disconnect)
+	orphanToken, err := dbState.NewToken(context.Background(), protocol.TO2Protocol)
+	if err != nil {
+		t.Fatal(err)
+	}
+	orphanCtx := dbState.TokenContext(context.Background(), orphanToken)
+	if err := dbState.InvalidateToken(orphanCtx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create upload dirs for the orphaned session
+	tmpDir := t.TempDir()
+	orphanDir := filepath.Join(tmpDir, "orphan-guid")
+	if err := os.MkdirAll(orphanDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	sm := moduleStateMachines{
+		DB: dbState,
+		states: map[string]*moduleStateMachineState{
+			activeToken: {
+				Completed: true,
+				Stop:      func() {},
+			},
+			orphanToken: {
+				Completed:  false,
+				UploadDirs: []string{orphanDir},
+				Stop:       func() {},
+			},
+		},
+	}
+
+	// CleanupModules for the active session should also sweep the orphan
+	sm.CleanupModules(activeCtx)
+
+	// Orphan's upload dir should be removed
+	if _, err := os.Stat(orphanDir); !os.IsNotExist(err) {
+		t.Error("expected orphaned upload directory to be removed by sweep")
+	}
+
+	// Both entries should be gone from the states map
+	if len(sm.states) != 0 {
+		t.Errorf("expected states map to be empty, got %d entries", len(sm.states))
+	}
+}

--- a/internal/db/state.go
+++ b/internal/db/state.go
@@ -202,7 +202,7 @@ func (s *State) NewToken(ctx context.Context, proto protocol.Protocol) (string, 
 	return token, nil
 }
 
-// InvalidateToken removes a session
+// InvalidateToken removes a session and its associated state from all tables.
 func (s *State) InvalidateToken(ctx context.Context) error {
 	sessionID, ok := s.TokenFromContext(ctx)
 	if !ok {
@@ -214,15 +214,47 @@ func (s *State) InvalidateToken(ctx context.Context) error {
 		return fdo.ErrInvalidSession
 	}
 
-	result := s.DB.Where("id = ?", decoded).Delete(&Session{})
-	if result.Error != nil {
-		return result.Error
-	}
-	if result.RowsAffected == 0 {
-		return fdo.ErrNotFound
+	// Clean up related session state tables before deleting the session,
+	// otherwise these rows become orphaned on every failed or timed-out session.
+	err = s.DB.Transaction(func(tx *gorm.DB) error {
+		for _, model := range []any{
+			&TO2Session{},
+			&TO1Session{},
+			&TO0Session{},
+			&ReplacementVoucher{},
+			&KeyExchange{},
+			&IncompleteVoucher{},
+			&DeviceInfo{},
+		} {
+			if err := tx.Where("session = ?", decoded).Delete(model).Error; err != nil {
+				return err
+			}
+		}
+		result := tx.Where("id = ?", decoded).Delete(&Session{})
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected == 0 {
+			return fdo.ErrNotFound
+		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 
 	return nil
+}
+
+// SessionExists checks whether a session for the given token still exists in the database.
+func (s *State) SessionExists(token string) bool {
+	decoded, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		return false
+	}
+	var count int64
+	s.DB.Model(&Session{}).Where("id = ?", decoded).Count(&count)
+	return count > 0
 }
 
 // TokenContext injects a token into the context
@@ -282,7 +314,7 @@ func (s *State) SetDeviceCertChain(ctx context.Context, chain []*x509.Certificat
 	}
 
 	return s.DB.Where("session = ?", sessionID).
-		Assign(map[string]interface{}{"x509_chain": chainBytes}).
+		Assign(map[string]any{"x509_chain": chainBytes}).
 		FirstOrCreate(&deviceInfo).Error
 }
 

--- a/test/ci/test-upload-cleanup-missing-file.sh
+++ b/test/ci/test-upload-cleanup-missing-file.sh
@@ -1,0 +1,223 @@
+#! /usr/bin/env bash
+#
+# This test verifies that orphaned GUID-based upload directories are
+# cleaned up when TO2 fails because a device file does not exist.
+#
+# Step 1: configure fdo.upload with a valid file and a non-existent file
+# Step 2: first onboard attempt fails because the device cannot find
+#         the non-existent file; the error triggers CleanupModules on
+#         the Owner which removes the orphaned upload directory
+# Step 3: stop the owner, reconfigure with only the valid file, restart
+# Step 4: second onboard attempt succeeds
+# Step 5: verify exactly one GUID directory remains
+#
+# This test builds both the client and server against kgiusti/go-fdo#issue-231
+# which fixes error message delivery (go-fdo#232).
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)/test-fsim-config.sh"
+
+# go-fdo branch with the error message fix (go-fdo#232)
+GO_FDO_FIX_REPO="https://github.com/kgiusti/go-fdo.git"
+GO_FDO_FIX_BRANCH="issue-231"
+
+# FSIM fdo.upload cleanup specific configuration
+fsim_upload_dir="${base_dir}/fsim/upload"
+owner_uploads_dir="${fsim_upload_dir}/owner"
+
+# Valid device file to upload
+device_file="upload-test-file"
+
+# Non-existent device file that triggers the failure
+missing_file="this-file-does-not-exist"
+
+# Clone the patched go-fdo library with the error message fix.
+setup_patched_go_fdo() {
+  go_fdo_patch_dir="${base_dir}/go-fdo-patched"
+  if [ ! -d "${go_fdo_patch_dir}" ]; then
+    log_info "Cloning go-fdo fix from ${GO_FDO_FIX_REPO} (branch: ${GO_FDO_FIX_BRANCH})"
+    git clone --depth 1 --branch "${GO_FDO_FIX_BRANCH}" "${GO_FDO_FIX_REPO}" "${go_fdo_patch_dir}"
+  fi
+}
+
+# Override: build the client against the patched go-fdo library
+install_client() {
+  setup_patched_go_fdo
+  local client_dir="${base_dir}/go-fdo-client-build"
+  git clone --depth 1 https://github.com/fido-device-onboard/go-fdo-client.git "${client_dir}"
+  pushd "${client_dir}" >/dev/null
+  go mod edit -replace "github.com/fido-device-onboard/go-fdo=${go_fdo_patch_dir}"
+  go mod tidy
+  go install .
+  popd >/dev/null
+}
+
+# Override: build the server against the patched go-fdo library
+install_server() {
+  setup_patched_go_fdo
+  mkdir -p "${bin_dir}"
+  go mod edit -replace "github.com/fido-device-onboard/go-fdo=${go_fdo_patch_dir}"
+  go mod tidy
+  make build && install -m 755 go-fdo-server "${bin_dir}" && rm -f go-fdo-server
+  # Revert go.mod changes so we don't leave the repo dirty
+  git checkout -- go.mod go.sum
+}
+
+# Owner config with both a valid file and a non-existent file
+configure_service_owner_with_missing_file() {
+  cat >"${owner_config_file}" <<EOF
+log:
+  level: "debug"
+db:
+  type: "sqlite"
+  dsn: "file:${base_dir}/owner.db"
+http:
+  ip: "${owner_dns}"
+  port: ${owner_port}
+device_ca:
+  cert: "${device_ca_crt}"
+owner:
+  key: "${owner_key}"
+  to0_insecure_tls: true
+  service_info:
+    fsims:
+      - fsim: "fdo.upload"
+        params:
+          dir: "${owner_uploads_dir}"
+          files:
+            - src: "${device_file}"
+            - src: "${missing_file}"
+EOF
+}
+
+# Owner config with only the valid file (for the successful retry)
+configure_service_owner() {
+  cat >"${owner_config_file}" <<EOF
+log:
+  level: "debug"
+db:
+  type: "sqlite"
+  dsn: "file:${base_dir}/owner.db"
+http:
+  ip: "${owner_dns}"
+  port: ${owner_port}
+device_ca:
+  cert: "${device_ca_crt}"
+owner:
+  key: "${owner_key}"
+  to0_insecure_tls: true
+  service_info:
+    fsims:
+      - fsim: "fdo.upload"
+        params:
+          dir: "${owner_uploads_dir}"
+          files:
+            - src: "${device_file}"
+EOF
+}
+
+generate_upload_file() {
+  prepare_payload "${credentials_dir}/${device_file}"
+}
+
+verify_upload_cleanup() {
+  local guid_dirs
+  guid_dirs=$(ls "${owner_uploads_dir}" | grep -c -e "^[a-f0-9]\{32\}$")
+
+  if [ "${guid_dirs}" -ne 1 ]; then
+    log_error "Expected exactly 1 GUID directory in ${owner_uploads_dir}, found ${guid_dirs}"
+  fi
+
+  local device_guid
+  device_guid=$(ls "${owner_uploads_dir}" | grep -e "^[a-f0-9]\{32\}$")
+  verify_equal_files "${credentials_dir}/${device_file}" "${owner_uploads_dir}/${device_guid}/${device_file}"
+}
+
+# Public entrypoint used by CI
+run_test() {
+
+  log_info "Setting the error trap handler"
+  trap on_failure ERR
+
+  log_info "Environment variables"
+  show_env
+
+  log_info "Creating directories"
+  directories+=("${owner_uploads_dir}")
+  create_directories
+
+  log_info "Generating service certificates"
+  generate_service_certs
+
+  log_info "Build and install 'go-fdo-client' binary (with go-fdo error message fix)"
+  install_client
+
+  log_info "Build and install 'go-fdo-server' binary (with go-fdo error message fix)"
+  install_server
+
+  log_info "Configuring services (with missing upload file)"
+  configure_service_manufacturer
+  configure_service_rendezvous
+  configure_service_owner_with_missing_file
+
+  log_info "Configure DNS and start services"
+  start_services
+
+  log_info "Wait for the services to be ready:"
+  wait_for_services_ready
+
+  log_info "Setting or updating Rendezvous Info (RendezvousInfo)"
+  set_or_update_rendezvous_info "${manufacturer_url}" "${rv_info}"
+
+  log_info "Adding Device CA certificate to rendezvous"
+  add_device_ca_cert "${rendezvous_url}" "${device_ca_crt}" | jq -r -M .
+
+  log_info "Run Device Initialization"
+  guid=$(run_device_initialization)
+  log_info "Device initialized with GUID: ${guid}"
+
+  log_info "Setting or updating Owner Redirect Info (RVTO2Addr)"
+  set_or_update_owner_redirect_info "${owner_url}" "${owner_service_name}" "${owner_dns}" "${owner_port}" "${owner_protocol}"
+
+  log_info "Sending Ownership Voucher to the Owner"
+  send_manufacturer_ov_to_owner "${manufacturer_url}" "${guid}" "${owner_url}"
+
+  log_info "Prepare upload payload on client side: ${device_file}"
+  generate_upload_file
+
+  log_info "Running FIDO Device Onboard (expected to fail due to missing file)"
+  # Use a short timeout so the client fails quickly instead of retrying
+  # for the full 300s default. One retry cycle (~2 min) is enough to
+  # create orphaned upload directories.
+  client_timeout="30s"
+  ! run_fido_device_onboard "${guid}" --debug ||
+    log_error "Expected Device onboard to fail!"
+  client_timeout="300s"
+
+  log_info "Verifying the upload error was logged"
+  find_in_log "$(get_device_onboard_log_file_path "${guid}")" "error uploading.*${missing_file}" ||
+    log_error "Expected upload error for ${missing_file} not found in log"
+
+  log_info "Stop owner, reconfigure with valid files only, restart"
+  stop_service "owner"
+  configure_service_owner
+  start_service "owner"
+  wait_for_service_ready "owner"
+
+  log_info "Re-running FIDO Device Onboard (should succeed)"
+  run_fido_device_onboard "${guid}" --debug
+
+  log_info "Verify orphaned upload directory was cleaned up"
+  verify_upload_cleanup
+
+  log_info "Unsetting the error trap handler"
+  trap - ERR
+  test_pass
+}
+
+# Allow running directly
+[[ "${BASH_SOURCE[0]}" != "$0" ]] || {
+  run_test
+  cleanup
+}

--- a/test/ci/test-upload-cleanup.sh
+++ b/test/ci/test-upload-cleanup.sh
@@ -1,0 +1,186 @@
+#! /usr/bin/env bash
+#
+# This test verifies that orphaned GUID-based upload directories are
+# cleaned up when TO2 fails and the device retries successfully.
+#
+# Step 1: configure fdo.upload followed by a fdo.command that fails on
+#         the first TO2 attempt but succeeds on the second
+# Step 2: first TO2 creates an upload directory, then the command fails;
+#         the device sends an error message triggering CleanupModules on
+#         the Owner which removes the orphaned upload directory
+# Step 3: after the FDO retry delay (~2 minutes), the second TO2 creates
+#         a new upload directory and the command succeeds
+# Step 4: verify exactly one GUID directory remains (from the successful
+#         attempt) and the uploaded file matches the source
+#
+# This test builds both the client and server against kgiusti/go-fdo#issue-231
+# which fixes error message delivery (go-fdo#232).
+
+set -euo pipefail
+
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)/test-fsim-config.sh"
+
+# go-fdo branch with the error message fix (go-fdo#232)
+GO_FDO_FIX_REPO="https://github.com/kgiusti/go-fdo.git"
+GO_FDO_FIX_BRANCH="issue-231"
+
+# FSIM fdo.upload cleanup specific configuration
+fsim_upload_dir="${base_dir}/fsim/upload"
+owner_uploads_dir="${fsim_upload_dir}/owner"
+
+# Device file to upload
+device_file="upload-cleanup-test-file"
+
+# State file used by the fail-once command. This is relative to the
+# go-fdo-client working directory (credentials_dir).
+fail_once_state=".fdo-upload-cleanup-first-run"
+
+# Clone the patched go-fdo library with the error message fix.
+# Used by install_client and install_server below.
+setup_patched_go_fdo() {
+  go_fdo_patch_dir="${base_dir}/go-fdo-patched"
+  if [ ! -d "${go_fdo_patch_dir}" ]; then
+    log_info "Cloning go-fdo fix from ${GO_FDO_FIX_REPO} (branch: ${GO_FDO_FIX_BRANCH})"
+    git clone --depth 1 --branch "${GO_FDO_FIX_BRANCH}" "${GO_FDO_FIX_REPO}" "${go_fdo_patch_dir}"
+  fi
+}
+
+# Override: build the client against the patched go-fdo library
+install_client() {
+  setup_patched_go_fdo
+  local client_dir="${base_dir}/go-fdo-client-build"
+  git clone --depth 1 https://github.com/fido-device-onboard/go-fdo-client.git "${client_dir}"
+  pushd "${client_dir}" >/dev/null
+  go mod edit -replace "github.com/fido-device-onboard/go-fdo=${go_fdo_patch_dir}"
+  go mod tidy
+  go install .
+  popd >/dev/null
+}
+
+# Override: build the server against the patched go-fdo library
+install_server() {
+  setup_patched_go_fdo
+  mkdir -p "${bin_dir}"
+  go mod edit -replace "github.com/fido-device-onboard/go-fdo=${go_fdo_patch_dir}"
+  go mod tidy
+  make build && install -m 755 go-fdo-server "${bin_dir}" && rm -f go-fdo-server
+  # Revert go.mod changes so we don't leave the repo dirty
+  git checkout -- go.mod go.sum
+}
+
+configure_service_owner() {
+  cat >"${owner_config_file}" <<EOF
+log:
+  level: "debug"
+db:
+  type: "sqlite"
+  dsn: "file:${base_dir}/owner.db"
+http:
+  ip: "${owner_dns}"
+  port: ${owner_port}
+device_ca:
+  cert: "${device_ca_crt}"
+owner:
+  key: "${owner_key}"
+  to0_insecure_tls: true
+  service_info:
+    fsims:
+      - fsim: "fdo.upload"
+        params:
+          dir: "${owner_uploads_dir}"
+          files:
+            - src: "${device_file}"
+      - fsim: "fdo.command"
+        params:
+          return_stdout: true
+          return_stderr: true
+          cmd: "bash"
+          args:
+            - "-c"
+            - "if [ ! -f ${fail_once_state} ]; then touch ${fail_once_state}; exit 1; fi; rm -f ${fail_once_state}"
+EOF
+}
+
+generate_upload_file() {
+  prepare_payload "${credentials_dir}/${device_file}"
+}
+
+verify_upload_cleanup() {
+  local guid_dirs
+  guid_dirs=$(ls "${owner_uploads_dir}" | grep -c -e "^[a-f0-9]\{32\}$")
+
+  if [ "${guid_dirs}" -ne 1 ]; then
+    log_error "Expected exactly 1 GUID directory in ${owner_uploads_dir}, found ${guid_dirs}"
+  fi
+
+  local device_guid
+  device_guid=$(ls "${owner_uploads_dir}" | grep -e "^[a-f0-9]\{32\}$")
+  verify_equal_files "${credentials_dir}/${device_file}" "${owner_uploads_dir}/${device_guid}/${device_file}"
+}
+
+# Public entrypoint used by CI
+run_test() {
+
+  log_info "Setting the error trap handler"
+  trap on_failure ERR
+
+  log_info "Environment variables"
+  show_env
+
+  log_info "Creating directories"
+  directories+=("${owner_uploads_dir}")
+  create_directories
+
+  log_info "Generating service certificates"
+  generate_service_certs
+
+  log_info "Build and install 'go-fdo-client' binary (with go-fdo error message fix)"
+  install_client
+
+  log_info "Build and install 'go-fdo-server' binary (with go-fdo error message fix)"
+  install_server
+
+  log_info "Configuring services"
+  configure_services
+
+  log_info "Configure DNS and start services"
+  start_services
+
+  log_info "Wait for the services to be ready:"
+  wait_for_services_ready
+
+  log_info "Setting or updating Rendezvous Info (RendezvousInfo)"
+  set_or_update_rendezvous_info "${manufacturer_url}" "${rv_info}"
+
+  log_info "Adding Device CA certificate to rendezvous"
+  add_device_ca_cert "${rendezvous_url}" "${device_ca_crt}" | jq -r -M .
+
+  log_info "Run Device Initialization"
+  guid=$(run_device_initialization)
+  log_info "Device initialized with GUID: ${guid}"
+
+  log_info "Setting or updating Owner Redirect Info (RVTO2Addr)"
+  set_or_update_owner_redirect_info "${owner_url}" "${owner_service_name}" "${owner_dns}" "${owner_port}" "${owner_protocol}"
+
+  log_info "Sending Ownership Voucher to the Owner"
+  send_manufacturer_ov_to_owner "${manufacturer_url}" "${guid}" "${owner_url}"
+
+  log_info "Prepare upload payload on client side: ${device_file}"
+  generate_upload_file
+
+  log_info "Running FIDO Device Onboard (first TO2 will fail, second will succeed)"
+  run_fido_device_onboard "${guid}" --debug
+
+  log_info "Verify orphaned upload directory was cleaned up"
+  verify_upload_cleanup
+
+  log_info "Unsetting the error trap handler"
+  trap - ERR
+  test_pass
+}
+
+# Allow running directly
+[[ "${BASH_SOURCE[0]}" != "$0" ]] || {
+  run_test
+  cleanup
+}


### PR DESCRIPTION
 - Track GUID-based upload directories created during `fdo.upload` in TO2 and clean them up if the session fails or the device disconnects, preventing orphaned partial uploads from accumulating on disk.
  - Clean up related session state table rows (to2_sessions, to1_sessions, to0_sessions, etc.) in `InvalidateToken`, which previously left them orphaned on every failed session.
