### PR TITLE
chore: bump golang version to latest 1.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -44,7 +44,7 @@ jobs:
       - name: Install golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -69,7 +69,7 @@ jobs:
       - name: Install golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -98,7 +98,7 @@ jobs:
       - name: Install golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -127,7 +127,7 @@ jobs:
       - name: install golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -156,7 +156,7 @@ jobs:
       - name: Install golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -185,7 +185,7 @@ jobs:
       - name: Install golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -214,7 +214,7 @@ jobs:
       - name: Install golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -243,7 +243,7 @@ jobs:
       - name: Install golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -272,7 +272,7 @@ jobs:
       - name: Install golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -301,7 +301,7 @@ jobs:
       - name: Install golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -330,7 +330,7 @@ jobs:
       - name: Install golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -359,7 +359,7 @@ jobs:
       - name: Install golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -388,7 +388,7 @@ jobs:
       - name: Install golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -417,7 +417,7 @@ jobs:
       - name: Install golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -446,7 +446,7 @@ jobs:
       - name: Install golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -475,7 +475,7 @@ jobs:
       - name: Install golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -46,7 +46,7 @@ jobs:
       - name: Install golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -78,7 +78,7 @@ jobs:
       - name: Install golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -108,7 +108,7 @@ jobs:
       - name: Install golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -138,7 +138,7 @@ jobs:
       - name: Install golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -168,7 +168,7 @@ jobs:
       - name: Install golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -198,7 +198,7 @@ jobs:
       - name: Install golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -228,7 +228,7 @@ jobs:
       - name: Install golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -259,7 +259,7 @@ jobs:
       - name: Install golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -289,7 +289,7 @@ jobs:
       - name: Install golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install golang
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Check out repository code
         uses: actions/checkout@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2024 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 WORKDIR /go/src/app
 COPY . .

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Prerequisites
 
-- Go 1.25.0 or later
+- Go 1.26.2 or later
 - `openssl` and `curl` available
 - `jq` to parse JSON output (optional)
 - `npx` to run `openapi-format`

--- a/docs/user-guide/dockerfile-usage.md
+++ b/docs/user-guide/dockerfile-usage.md
@@ -9,7 +9,7 @@ The Dockerfile in this repository creates a minimal, secure container image for 
 ### Image Characteristics
 
 - **Base Image**: `gcr.io/distroless/static-debian12:nonroot` (minimal, security-hardened)
-- **Build Stage**: `golang:1.25-alpine` (compact build environment)
+- **Build Stage**: `golang:1.26-alpine` (compact build environment)
 - **Included Binaries**:
   - `go-fdo-server` - main server binary
   - `curl` - static curl binary for health checks

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fido-device-onboard/go-fdo-server
 
-go 1.25.7
+go 1.26.2
 
 require (
 	github.com/elnormous/contenttype v1.0.4


### PR DESCRIPTION
Fixes the following vulnerabilities:

 Vulnerability #1: GO-2026-4947
     Unexpected work during chain building in crypto/x509
   More info: https://pkg.go.dev/vuln/GO-2026-4947
   Standard library
     Found in: crypto/x509@go1.25.7

 Vulnerability #2: GO-2026-4946
     Inefficient policy validation in crypto/x509
   More info: https://pkg.go.dev/vuln/GO-2026-4946
   Standard library
     Found in: crypto/x509@go1.25.7

 Vulnerability #3: GO-2026-4870
     Unauthenticated TLS 1.3 KeyUpdate record can cause persistent connection
     retention and DoS in crypto/tls
   More info: https://pkg.go.dev/vuln/GO-2026-4870
   Standard library
     Found in: crypto/tls@go1.25.7

 Vulnerability #4: GO-2026-4602
     FileInfo can escape from a Root in os
   More info: https://pkg.go.dev/vuln/GO-2026-4602
   Standard library
     Found in: os@go1.25.7

 Vulnerability #5: GO-2026-4601
     Incorrect parsing of IPv6 host literals in net/url
   More info: https://pkg.go.dev/vuln/GO-2026-4601
   Standard library
     Found in: os@go1.25.7