### PR TITLE
fix: strip date from generated man pages for reproducible builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,9 +49,14 @@ vet:
 test:
 	go test -v ./...
 
+# Strip the date from generated man pages to keep them deterministic.
+# See https://github.com/fido-device-onboard/go-fdo-server/issues/220
 .PHONY: man
 man:
-	go run ./internal/tools/docgen -format man
+	SOURCE_DATE_EPOCH=0 go run ./internal/tools/docgen -format man
+	for f in docs/man/*.1; do \
+		sed 's/\(\.TH "[^"]*" "[^"]*"\) "[^"]*"/\1/' "$$f" > "$$f.tmp" && mv "$$f.tmp" "$$f"; \
+	done
 
 .PHONY: shfmt
 shfmt:

--- a/docs/man/go-fdo-server-manufacturing.1
+++ b/docs/man/go-fdo-server-manufacturing.1
@@ -1,5 +1,5 @@
 .nh
-.TH "GO-FDO-SERVER-MANUFACTURING" "1" "May 2026" "go-fdo-server" "Go FDO Server"
+.TH "GO-FDO-SERVER-MANUFACTURING" "1" "go-fdo-server" "Go FDO Server"
 
 .SH NAME
 go-fdo-server-manufacturing - Run an FDO Manufacturing server

--- a/docs/man/go-fdo-server-owner.1
+++ b/docs/man/go-fdo-server-owner.1
@@ -1,5 +1,5 @@
 .nh
-.TH "GO-FDO-SERVER-OWNER" "1" "May 2026" "go-fdo-server" "Go FDO Server"
+.TH "GO-FDO-SERVER-OWNER" "1" "go-fdo-server" "Go FDO Server"
 
 .SH NAME
 go-fdo-server-owner - Run an FDO Owner server

--- a/docs/man/go-fdo-server-rendezvous.1
+++ b/docs/man/go-fdo-server-rendezvous.1
@@ -1,5 +1,5 @@
 .nh
-.TH "GO-FDO-SERVER-RENDEZVOUS" "1" "May 2026" "go-fdo-server" "Go FDO Server"
+.TH "GO-FDO-SERVER-RENDEZVOUS" "1" "go-fdo-server" "Go FDO Server"
 
 .SH NAME
 go-fdo-server-rendezvous - Run an FDO Rendezvous server

--- a/docs/man/go-fdo-server.1
+++ b/docs/man/go-fdo-server.1
@@ -1,5 +1,5 @@
 .nh
-.TH "GO-FDO-SERVER" "1" "May 2026" "go-fdo-server" "Go FDO Server"
+.TH "GO-FDO-SERVER" "1" "go-fdo-server" "Go FDO Server"
 
 .SH NAME
 go-fdo-server - Run a FIDO Device Onboard (FDO) server


### PR DESCRIPTION
The man page generator embeds the current month into the .TH header, causing CI to fail at the start of each month due to uncommitted changes after build.

Set SOURCE_DATE_EPOCH=0 and post-process with sed to remove the date field from the .TH directive.

Closes: #220

Assisted-by: Claude:claude-opus-4-6