### PR TITLE
ci: implement least-privileged token permissions on workflows

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: '19 20 * * 6'
 
+permissions:
+  contents: read
+
 jobs:
   check-spelling:
     name: check spelling

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
 
 name: Continuous integration
 
+permissions:
+  contents: read
+
 jobs:
   test-build:
     name: Run the full build via the Makefile

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -6,6 +6,9 @@ on:
 
 name: Container Tests
 
+permissions:
+  contents: read
+
 jobs:
   test-container-onboarding:
     name: Test FIDO device onboarding

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -6,6 +6,9 @@ on:
 
 name: Post coverage report to PR
 
+permissions:
+  contents: read
+
 jobs:
   comment:
     name: Post coverage report

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,10 +6,16 @@ on:
 
 name: Go test coverage
 
+permissions:
+  contents: read
+
 jobs:
   coverage:
     name: Measure test coverage (unit + integration tests)
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
     steps:
       - name: Install golang
         uses: actions/setup-go@v6


### PR DESCRIPTION
Explicitly set the workflow permissions to read-only at the topmost level. Override where necessary at the run level.

Closes: #227