### PR TITLE
chore: set Go version to 1.26

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Prerequisites
 
-- Go 1.26.2 or later
+- Go 1.26 or later
 - `openssl` and `curl` available
 - `jq` to parse JSON output (optional)
 - `npx` to run `openapi-format`

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fido-device-onboard/go-fdo-server
 
-go 1.26.2
+go 1.26
 
 require (
 	github.com/elnormous/contenttype v1.0.4


### PR DESCRIPTION
### What
Set Go version to `1.26` in `go.mod` and update `README.md`.

### Why
Align with the Go version used in the `go-fdo-client` repository (see [`fido-device-onboard/go-fdo-client#121`](https://github.com/fido-device-onboard/go-fdo-client/pull/121)).

Assisted-by: Claude (claude-opus-4-6)