### PR TITLE
ci: point Packit test jobs to go-fdo-ci for FMF test definitions

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -127,6 +127,11 @@ jobs:
   - job: tests
     trigger: pull_request
     identifier: rpm-e2e-fedora
+    # Track main to always use the latest shared test definitions from go-fdo-ci
+    <<: &fmf_source
+      fmf_url: https://github.com/fido-device-onboard/go-fdo-ci
+      fmf_ref: main
+      use_target_repo_for_fmf_url: true
     tmt_plan: test/fmf/plans/rpm-e2e
     packages: [go-fdo-server-fedora]
     targets: *copr_fedora_targets
@@ -134,6 +139,7 @@ jobs:
   - job: tests
     trigger: pull_request
     identifier: bootc-e2e-fedora
+    <<: *fmf_source
     tmt_plan: test/fmf/plans/bootc-e2e
     packages: [go-fdo-server-fedora]
     targets: # Temporarily disabling rawhide due to bug https://issues.redhat.com/browse/HMS-9867
@@ -180,6 +186,7 @@ jobs:
   - job: tests
     trigger: pull_request
     identifier: rpm-e2e-centos
+    <<: *fmf_source
     tmt_plan: test/fmf/plans/rpm-e2e
     packages: [go-fdo-server-centos]
     targets: *copr_centos_targets


### PR DESCRIPTION
Update all three Packit test jobs (rpm-e2e-fedora, bootc-e2e-fedora, rpm-e2e-centos) to fetch FMF plans and test metadata from the shared go-fdo-ci repository instead of the local test/fmf/ directory.

Adds fmf_url, fmf_ref, and use_target_repo_for_fmf_url to ensure centralized test definitions and prevent fork PRs from bypassing tests.

Co-Authored-By: Claude Sonnet 4.5

Requires: https://github.com/fido-device-onboard/go-fdo-ci/pull/7