### PR TITLE
fix: append currentldflags to preserve aarch64 BTI branch protection

### DIFF
--- a/build/package/rpm/go-fdo-server.spec
+++ b/build/package/rpm/go-fdo-server.spec
@@ -56,7 +56,7 @@ devices when they are first powered on in their final location.
 # https://discussion.fedoraproject.org/t/why-does-the-go-compiler-uses-x-nodwarf5-by-default/179804
 # https://github.com/golang/go/issues/75079
 export GOEXPERIMENT="nodwarf5"
-export GO_LDFLAGS="-X %{goipath}/internal/version.VERSION=%{version}"
+export GO_LDFLAGS='-X %{goipath}/internal/version.VERSION=%{version} %{?currentldflags}'
 %gobuild -o %{gobuilddir}/bin/go-fdo-server %{goipath}
 
 %install


### PR DESCRIPTION
Setting GO_LDFLAGS without including %{currentldflags} overwrote Fedora's architecture-specific linker flags, causing the BTI (Branch Target Identification) hardened build check to fail on aarch64.

Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>