### PR TITLE
fix: pluralize voucher OpenAPI tag to match resource endpoints

### DIFF
--- a/api/v2/manufacturer/openapi.json
+++ b/api/v2/manufacturer/openapi.json
@@ -783,7 +783,7 @@
           }
         },
         "tags": [
-          "voucher"
+          "vouchers"
         ]
       },
       "post": {
@@ -891,7 +891,7 @@
           }
         },
         "tags": [
-          "voucher"
+          "vouchers"
         ]
       }
     },
@@ -1014,7 +1014,7 @@
           }
         },
         "tags": [
-          "voucher"
+          "vouchers"
         ]
       },
       "delete": {
@@ -1055,7 +1055,7 @@
           }
         },
         "tags": [
-          "voucher"
+          "vouchers"
         ]
       }
     },
@@ -1138,7 +1138,7 @@
           }
         },
         "tags": [
-          "voucher"
+          "vouchers"
         ]
       }
     },
@@ -2609,7 +2609,7 @@
       "description": "Operations related to rendezvous info management"
     },
     {
-      "name": "voucher",
+      "name": "vouchers",
       "description": "Operations related to ownership voucher management"
     }
   ]

--- a/api/v2/manufacturer/openapi.yaml
+++ b/api/v2/manufacturer/openapi.yaml
@@ -62,7 +62,7 @@ tags:
     description: Server's health monitoring
   - name: rvinfo
     description: Operations related to rendezvous info management
-  - name: voucher
+  - name: vouchers
     description: Operations related to ownership voucher management
 paths:
   /health:

--- a/api/v2/owner/openapi.json
+++ b/api/v2/owner/openapi.json
@@ -1512,7 +1512,7 @@
           }
         },
         "tags": [
-          "voucher"
+          "vouchers"
         ]
       },
       "post": {
@@ -1620,7 +1620,7 @@
           }
         },
         "tags": [
-          "voucher"
+          "vouchers"
         ]
       }
     },
@@ -1743,7 +1743,7 @@
           }
         },
         "tags": [
-          "voucher"
+          "vouchers"
         ]
       },
       "delete": {
@@ -1784,7 +1784,7 @@
           }
         },
         "tags": [
-          "voucher"
+          "vouchers"
         ]
       }
     },
@@ -1867,7 +1867,7 @@
           }
         },
         "tags": [
-          "voucher"
+          "vouchers"
         ]
       }
     },
@@ -4129,7 +4129,7 @@
       "description": "Operations related to rendezvous TO2 address management"
     },
     {
-      "name": "voucher",
+      "name": "vouchers",
       "description": "Operations related to ownership voucher management"
     }
   ]

--- a/api/v2/owner/openapi.yaml
+++ b/api/v2/owner/openapi.yaml
@@ -66,7 +66,7 @@ tags:
     description: Operations related to trusted device CA certificates management
   - name: rvto2addr
     description: Operations related to rendezvous TO2 address management
-  - name: voucher
+  - name: vouchers
     description: Operations related to ownership voucher management
 paths:
   /health:

--- a/api/v2/voucher/openapi.yaml
+++ b/api/v2/voucher/openapi.yaml
@@ -7,7 +7,7 @@ info:
     name: Go FDO Server API Support
     url: https://github.com/fido-device-onboard/go-fdo-server/issues
 tags:
-  - name: voucher
+  - name: vouchers
     description: |
       Operations related to ownership voucher management.
 
@@ -18,7 +18,7 @@ paths:
   /vouchers:
     get:
       tags:
-        - voucher
+        - vouchers
       summary: List all ownership vouchers
       description: |
         Retrieves a paginated, filterable, and sortable list of all ownership vouchers.
@@ -152,7 +152,7 @@ paths:
           $ref: "../components/openapi.yaml#/components/responses/InternalServerError"
     post:
       tags:
-        - voucher
+        - vouchers
       summary: Import ownership voucher(s)
       description: |
         Imports one or more ownership vouchers into the system.
@@ -248,7 +248,7 @@ paths:
   /vouchers/{guid}:
     get:
       tags:
-        - voucher
+        - vouchers
       summary: Get an ownership voucher by GUID
       description: |
         Retrieves a specific ownership voucher by its device GUID.
@@ -340,7 +340,7 @@ paths:
           $ref: "../components/openapi.yaml#/components/responses/InternalServerError"
     delete:
       tags:
-        - voucher
+        - vouchers
       summary: Delete an ownership voucher by GUID
       description: Deletes a specific ownership voucher by its device GUID.
       operationId: DeleteOwnershipVoucher
@@ -369,7 +369,7 @@ paths:
   /vouchers/{guid}/extend:
     post:
       tags:
-        - voucher
+        - vouchers
       summary: Extend an ownership voucher
       description: |
         Extends an ownership voucher by adding a new ownership entry. This operation
@@ -452,7 +452,7 @@ paths:
   /vouchers/verify-ownership:
     post:
       tags:
-        - voucher
+        - vouchers
       summary: Re-verify ownership of all vouchers
       description: |
         Scans all vouchers and updates the ownership_verified flag by comparing


### PR DESCRIPTION
## Summary
- Renames the OpenAPI tag from `voucher` (singular) to `vouchers` (plural) across the manufacturer, owner, and voucher V2 API specs
- Aligns the tag name with the `/vouchers` resource path for consistency

## Test plan
- [ ] Verify Swagger UI groups endpoints correctly under the renamed tag
- [ ] Confirm no references to the old singular tag remain in the specs

🤖 Generated with [Claude Code](https://claude.ai/claude-code)